### PR TITLE
accpet raintank/schema.V0 metrics

### DIFF
--- a/api/metrics.go
+++ b/api/metrics.go
@@ -104,6 +104,13 @@ func metricsBinary(ctx *Context, compressed bool) {
 
 		if ctx.IsAdmin {
 			for _, m := range metricData.Metrics {
+				if m.Metric == "" {
+					m.Metric = m.Name
+				}
+				if m.Mtype == "" {
+					m.Mtype = "gauge"
+				}
+
 				if err := m.Validate(); err != nil {
 					ctx.JSON(400, err.Error())
 					return
@@ -112,6 +119,12 @@ func metricsBinary(ctx *Context, compressed bool) {
 		} else {
 			for _, m := range metricData.Metrics {
 				m.OrgId = int(ctx.OrgId)
+				if m.Metric == "" {
+					m.Metric = m.Name
+				}
+				if m.Mtype == "" {
+					m.Mtype = "gauge"
+				}
 				if err := m.Validate(); err != nil {
 					ctx.JSON(400, err.Error())
 					return


### PR DESCRIPTION
Some customers are still sending V0 metrics. When decoded into
a schema.V1 metric the metric.Mtype will be empty and the metric.Metric
may also be empty. These fields need to be populated to pass validation.