### PR TITLE
proxy delete endpoint to metrictank

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,6 +19,7 @@ func InitRoutes(metrics met.Backend, m *macaron.Macaron, adminKey string) {
 	m.Use(RequestStats())
 
 	m.Get("/", index)
+	m.Post("/metrics/delete", Auth(adminKey), MetrictankProxy)
 	m.Post("/metrics", Auth(adminKey), Metrics)
 	m.Post("/events", Auth(adminKey), Events)
 	m.Any("/graphite/*", Auth(adminKey), GraphiteProxy)

--- a/api/metrictank.go
+++ b/api/metrictank.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"github.com/raintank/tsdb-gw/metrictank"
+)
+
+func MetrictankProxy(c *Context) {
+	// currently the only action on metrictank is delete
+	proxy := metrictank.ProxyDelete(c.OrgId)
+	proxy.ServeHTTP(c.RW(), c.Req.Request)
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/raintank/tsdb-gw/event_publish"
 	"github.com/raintank/tsdb-gw/graphite"
 	"github.com/raintank/tsdb-gw/metric_publish"
+	"github.com/raintank/tsdb-gw/metrictank"
 	"github.com/raintank/worldping-api/pkg/log"
 	"github.com/rakyll/globalconf"
 )
@@ -46,6 +47,7 @@ var (
 	statsdType   = flag.String("statsd-type", "standard", "statsd type: standard or datadog")
 
 	graphiteUrl      = flag.String("graphite-url", "http://localhost:8080", "graphite-api address")
+	metrictankUrl    = flag.String("metrictank-url", "http://localhost:6060", "metrictank address")
 	worldpingUrl     = flag.String("worldping-url", "http://localhost/", "worldping-api address")
 	elasticsearchUrl = flag.String("elasticsearch-url", "http://localhost:9200", "elasticsearch server address")
 	esIndex          = flag.String("es-index", "events", "elasticsearch index name")
@@ -115,6 +117,9 @@ func main() {
 	api.InitRoutes(stats, m, *adminKey)
 
 	if err := graphite.Init(*graphiteUrl, *worldpingUrl); err != nil {
+		log.Fatal(4, err.Error())
+	}
+	if err := metrictank.Init(*metrictankUrl); err != nil {
 		log.Fatal(4, err.Error())
 	}
 	if err := elasticsearch.Init(*elasticsearchUrl, *esIndex); err != nil {

--- a/metrictank/metrictank.go
+++ b/metrictank/metrictank.go
@@ -1,0 +1,34 @@
+package metrictank
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+
+	"github.com/raintank/tsdb-gw/util"
+)
+
+var (
+	MetrictankUrl *url.URL
+)
+
+func Init(metrictankUrl string) error {
+	var err error
+	MetrictankUrl, err = url.Parse(metrictankUrl)
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func ProxyDelete(orgId int64) *httputil.ReverseProxy {
+	director := func(req *http.Request) {
+		req.URL.Scheme = MetrictankUrl.Scheme
+		req.URL.Host = MetrictankUrl.Host
+		req.URL.Path = util.JoinUrlFragments(MetrictankUrl.Path, "/metrics/delete")
+		req.Header.Del("X-Org-Id")
+		req.Header.Add("X-Org-Id", strconv.FormatInt(orgId, 10))
+	}
+	return &httputil.ReverseProxy{Director: director}
+}


### PR DESCRIPTION
directly proxy requests on `/metrics/delete` to the metrictank
endpoint, bypassing graphite-api.

fixes #21 

example:
```
mst@ubuntu:~$ curl  -H 'X-Org-Id: 1' 'http://localhost/metrics/delete' --form 'query=some.id.of.a.metric.1'
{"deletedDefs":1}
mst@ubuntu:~$ curl  -H 'X-Org-Id: 1' 'http://localhost/metrics/delete' --form 'query=some.id.of.a.metric.1'
{"deletedDefs":0}
```