### PR TITLE
Reuse reverse proxies instead of reinstantiating

### DIFF
--- a/api/graphite.go
+++ b/api/graphite.go
@@ -5,7 +5,5 @@ import (
 )
 
 func GraphiteProxy(c *Context) {
-	proxyPath := c.Params("*")
-	proxy := graphite.Proxy(c.OrgId, proxyPath, c.Req.Request)
-	proxy.ServeHTTP(c.Resp, c.Req.Request)
+	graphite.Proxy(c.OrgId, c.Context)
 }


### PR DESCRIPTION
The transport to the backends is a member of `ReverseProxy`, so it would be better if we could reuse them instead of reinstantiating on each request.

I tested in the QA env and i can still push metrics via carbon-relay-ng and query them from Grafana.