### PR TITLE
Stats and logs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -2,19 +2,9 @@ package api
 
 import (
 	"gopkg.in/macaron.v1"
-	"github.com/raintank/met"
 )
 
-var (
-	requestLatency met.Timer
-	requestSize    met.Meter
-	response2xx    met.Count
-	response3xx    met.Count
-	response4xx    met.Count
-	response5xx    met.Count
-)
-
-func InitRoutes(metrics met.Backend, m *macaron.Macaron, adminKey string) {
+func InitRoutes(m *macaron.Macaron, adminKey string) {
 	m.Use(GetContextHandler())
 	m.Use(RequestStats())
 
@@ -24,13 +14,6 @@ func InitRoutes(metrics met.Backend, m *macaron.Macaron, adminKey string) {
 	m.Post("/events", Auth(adminKey), Events)
 	m.Any("/graphite/*", Auth(adminKey), GraphiteProxy)
 	m.Any("/elasticsearch/*", Auth(adminKey), ElasticsearchProxy)
-
-	requestLatency = metrics.NewTimer("request.duration", 0)
-	requestSize = metrics.NewMeter("request.size", 0)
-	response2xx = metrics.NewCount("request.2xx")
-	response3xx = metrics.NewCount("request.3xx")
-	response4xx = metrics.NewCount("request.4xx")
-	response5xx = metrics.NewCount("request.5xx")
 }
 
 func index(ctx *macaron.Context) {

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -2,9 +2,13 @@ package api
 
 import (
 	"encoding/base64"
+	"fmt"
+	"path"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/raintank/metrictank/stats"
 	"github.com/raintank/raintank-apps/pkg/auth"
 	"github.com/raintank/worldping-api/pkg/log"
 	"gopkg.in/macaron.v1"
@@ -80,25 +84,80 @@ func getApiKey(c *Context) (string, error) {
 	return "", nil
 }
 
+type requestStats struct {
+	sync.Mutex
+	responseCounts    map[string]map[int]*stats.Counter32
+	latencyHistograms map[string]*stats.LatencyHistogram15s32
+	sizeMeters        map[string]*stats.Meter32
+}
+
+func (r *requestStats) PathStatusCount(path string, status int) {
+	r.Lock()
+	p, ok := r.responseCounts[path]
+	if !ok {
+		p = make(map[int]*stats.Counter32)
+		r.responseCounts[path] = p
+	}
+	c, ok := p[status]
+	if !ok {
+		c = stats.NewCounter32(fmt.Sprintf("api.request.%s.status.%d", path, status))
+		p[status] = c
+	}
+	r.Unlock()
+	c.Inc()
+}
+
+func (r *requestStats) PathLatency(path string, dur time.Duration) {
+	r.Lock()
+	p, ok := r.latencyHistograms[path]
+	if !ok {
+		p = stats.NewLatencyHistogram15s32(fmt.Sprintf("api.request.%s", path))
+		r.latencyHistograms[path] = p
+	}
+	r.Unlock()
+	p.Value(dur)
+}
+
+func (r *requestStats) PathSize(path string, size int) {
+	r.Lock()
+	p, ok := r.sizeMeters[path]
+	if !ok {
+		p = stats.NewMeter32(fmt.Sprintf("api.request.%s.size", path), false)
+		r.sizeMeters[path] = p
+	}
+	r.Unlock()
+	p.Value(size)
+}
+
 // RequestStats returns a middleware that tracks request metrics.
 func RequestStats() macaron.Handler {
+	stats := requestStats{
+		responseCounts:    make(map[string]map[int]*stats.Counter32),
+		latencyHistograms: make(map[string]*stats.LatencyHistogram15s32),
+		sizeMeters:        make(map[string]*stats.Meter32),
+	}
+
 	return func(ctx *macaron.Context) {
 		start := time.Now()
 		rw := ctx.Resp.(macaron.ResponseWriter)
+		// call next handler. This will return after all handlers
+		// have completed and the request has been sent.
 		ctx.Next()
-
 		status := rw.Status()
-		switch {
-		case status >= 200 && status < 300:
-			response2xx.Inc(1)
-		case status >= 300 && status < 400:
-			response3xx.Inc(1)
-		case status >= 400 && status < 500:
-			response4xx.Inc(1)
-		case status >= 500:
-			response5xx.Inc(1)
+		path := pathSlug(ctx.Req.URL.Path)
+		stats.PathStatusCount(path, status)
+		stats.PathLatency(path, time.Since(start))
+		// only record the request size if the request succeeded.
+		if status < 300 {
+			stats.PathSize(path, rw.Size())
 		}
-		requestLatency.Value(time.Since(start))
-		requestSize.Value(int64(rw.Size()))
 	}
+}
+
+func pathSlug(p string) string {
+	slug := strings.TrimPrefix(path.Clean(p), "/")
+	if slug == "" {
+		slug = "root"
+	}
+	return strings.Replace(slug, "/", "_", -1)
 }


### PR DESCRIPTION
use raintank/metrictank/stats library to send stats directly to graphite.  Statsd is flaky in our hosted-metrics platform, with the tsdb-gw where tsdb-gw services just randomly stop sending metrics.

use a logHandler from the gorillatookit to write apache common log format logs of http requests to stdout