### PR TITLE
log error when Auth check fails

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -54,6 +54,7 @@ func Auth(adminKey string) macaron.Handler {
 				ctx.JSON(401, err.Error())
 				return
 			}
+			log.Error(3, "failed to perform authentication: %q", err.Error())
 			ctx.JSON(500, err.Error())
 			return
 		}


### PR DESCRIPTION
in particular, all 5xx responses should have an error log.
now they all do.