### PR TITLE
proxy /metrics/index.json and /graphite/metrics/index.json directly to MT

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -90,8 +90,10 @@ func (a *Api) InitRoutes(m *macaron.Macaron) {
 	m.Use(RequestStats())
 
 	m.Get("/", index)
-	m.Post("/metrics/delete", a.Auth(), MetrictankProxy)
+	m.Post("/metrics/delete", a.Auth(), MetrictankProxy("/metrics/delete"))
 	m.Post("/metrics", a.Auth(), Metrics)
+	m.Get("/metrics/index.json", a.Auth(), MetrictankProxy("/metrics/index.json"))
+	m.Get("/graphite/metrics/index.json", a.Auth(), MetrictankProxy("/metrics/index.json"))
 	m.Any("/graphite/*", a.Auth(), GraphiteProxy)
 }
 

--- a/api/metrictank.go
+++ b/api/metrictank.go
@@ -4,8 +4,9 @@ import (
 	"github.com/raintank/tsdb-gw/metrictank"
 )
 
-func MetrictankProxy(c *Context) {
-	// currently the only action on metrictank is delete
-	proxy := metrictank.ProxyDelete(c.OrgId)
-	proxy.ServeHTTP(c.Resp, c.Req.Request)
+func MetrictankProxy(path string) func(c *Context) {
+	return func(c *Context) {
+		proxy := metrictank.Proxy(c.OrgId, path)
+		proxy.ServeHTTP(c.Resp, c.Req.Request)
+	}
 }

--- a/metrictank/metrictank.go
+++ b/metrictank/metrictank.go
@@ -22,11 +22,11 @@ func Init(metrictankUrl string) error {
 	return err
 }
 
-func ProxyDelete(orgId int) *httputil.ReverseProxy {
+func Proxy(orgId int, path string) *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		req.URL.Scheme = MetrictankUrl.Scheme
 		req.URL.Host = MetrictankUrl.Host
-		req.URL.Path = util.JoinUrlFragments(MetrictankUrl.Path, "/metrics/delete")
+		req.URL.Path = util.JoinUrlFragments(MetrictankUrl.Path, path)
 		req.Header.Del("X-Org-Id")
 		req.Header.Add("X-Org-Id", strconv.FormatInt(int64(orgId), 10))
 	}


### PR DESCRIPTION
This PR proxies requests for index.json directly to MT, bypassing graphite-web.

I added support for querying `/metrics/index.json` in addition to `/graphite/metrics.json` since people seem to do that a lot.

Not sure if we want to also support `/metrics/find` (and/or hijack `/graphite/metrics/find` or all of `/graphite/metrics`) though now that would be fairly easy.