### PR TITLE
tune send buffer

### DIFF
--- a/metric_publish/publish.go
+++ b/metric_publish/publish.go
@@ -31,7 +31,6 @@ var (
 	codec           string
 	enabled         bool
 	partitionScheme string
-	flushFreq       time.Duration
 	partitioner     Partitioner
 	maxInFlight     int
 	bufferMaxMs     int
@@ -87,7 +86,6 @@ func init() {
 	flag.StringVar(&codec, "metrics-kafka-comp", "snappy", "compression: none|gzip|snappy")
 	flag.BoolVar(&enabled, "metrics-publish", false, "enable metric publishing")
 	flag.StringVar(&partitionScheme, "metrics-partition-scheme", "bySeries", "method used for paritioning metrics. (byOrg|bySeries)")
-	flag.DurationVar(&flushFreq, "metrics-flush-freq", time.Millisecond*50, "The best-effort frequency of flushes to kafka")
 	flag.IntVar(&maxInFlight, "metrics-max-in-flight", 1000000, "The maximum number of messages in flight per broker connection")
 	flag.IntVar(&bufferMaxMs, "metrics-buffer-max-ms", 100, "Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers")
 }

--- a/metric_publish/publish.go
+++ b/metric_publish/publish.go
@@ -34,6 +34,7 @@ var (
 	flushFreq       time.Duration
 	partitioner     Partitioner
 	maxInFlight     int
+	bufferMaxMs     int
 
 	bufferPool = util.NewBufferPool()
 )
@@ -88,6 +89,7 @@ func init() {
 	flag.StringVar(&partitionScheme, "metrics-partition-scheme", "bySeries", "method used for paritioning metrics. (byOrg|bySeries)")
 	flag.DurationVar(&flushFreq, "metrics-flush-freq", time.Millisecond*50, "The best-effort frequency of flushes to kafka")
 	flag.IntVar(&maxInFlight, "metrics-max-in-flight", 1000000, "The maximum number of messages in flight per broker connection")
+	flag.IntVar(&bufferMaxMs, "metrics-buffer-max-ms", 100, "Delay in milliseconds to wait for messages in the producer queue to accumulate before constructing message batches (MessageSets) to transmit to brokers")
 }
 
 func Init(broker string) {
@@ -102,6 +104,7 @@ func Init(broker string) {
 	config.SetKey("bootstrap.servers", broker)
 	config.SetKey("compression.codec", codec)
 	config.SetKey("max.in.flight", maxInFlight)
+	config.SetKey("queue.buffering.max.ms", bufferMaxMs)
 
 	producer, err = kafka.NewProducer(&config)
 	if err != nil {


### PR DESCRIPTION
This improves the performance by a lot

Explanation of the screenshot:

- Up until 18:10 it running the old tsdb-gw with sarama
- At 18:10 I switched it to the `0.8.0` and the metric publishing time exploded
- 18:26 I deployed this branch with default settings and performance improved
- 18:31 I've increased the `metrics-buffer-max-ms` setting to `1000` and performance looked about the same like with Sarama

![screenshot from 2018-02-22 18-34-29](https://user-images.githubusercontent.com/195371/36535485-c8e2ec20-1804-11e8-9fee-dafbb12a7d98.png)
