### PR TITLE
cortex publish interface

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	addr     = flag.String("addr", "localhost:80", "http service address")
+	addr     = flag.String("addr", ":80", "http service address")
 	ssl      = flag.Bool("ssl", false, "use https")
 	certFile = flag.String("cert-file", "", "SSL certificate file")
 	keyFile  = flag.String("key-file", "", "SSL key file")

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -23,7 +23,7 @@ import (
 
 var (
 	requestDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "tsdb_gw",
+		Namespace: "cortex_gw",
 		Name:      "request_duration_seconds",
 		Help:      "Time (in seconds) spent serving HTTP requests.",
 		Buckets:   prometheus.ExponentialBuckets(.05, 2, 10),

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -84,6 +84,7 @@ func (a *Api) Auth() macaron.Handler {
 		}
 
 		if key == "" {
+			log.Debugf("no key specified")
 			ctx.JSON(401, "Unauthorized")
 			return
 		}

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -35,6 +35,7 @@ type AuthPlugin interface {
 }
 
 func GetAuthPlugin(name string) AuthPlugin {
+	log.Debugf("initializing auth plugin %s", name)
 	switch name {
 	case "grafana":
 		return NewGrafanaComAuth()

--- a/auth/grafana_com_instance.go
+++ b/auth/grafana_com_instance.go
@@ -24,9 +24,11 @@ func (a *GrafanaComInstanceAuth) Auth(username, password string) (*User, error) 
 	u, err := gcom.Auth(AdminKey, password)
 	if err != nil {
 		if err == gcom.ErrInvalidApiKey {
+			log.Debugf("failed to authenticate request: %v", err)
 			return nil, ErrInvalidCredentials
 		}
 		if err == gcom.ErrInvalidOrgId {
+			log.Debugf("failed to authenticate request: %v", err)
 			return nil, ErrInvalidOrgId
 		}
 		return nil, err

--- a/cmd/cortex-gw/main.go
+++ b/cmd/cortex-gw/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/raintank/tsdb-gw/ingest"
 	"github.com/raintank/tsdb-gw/ingest/carbon"
 	"github.com/raintank/tsdb-gw/publish"
-	cortex_publish "github.com/raintank/tsdb-gw/publish/cortex"
+	cortexPublish "github.com/raintank/tsdb-gw/publish/cortex"
 	"github.com/raintank/tsdb-gw/query/cortex"
 	"github.com/raintank/tsdb-gw/util"
 	log "github.com/sirupsen/logrus"
@@ -67,10 +67,10 @@ func main() {
 	}
 	defer traceCloser.Close()
 
-	inputs := make([]Stoppable, 0)
+	var inputs []Stoppable
 
 	if *cortexWriteEnabled {
-		publish.Init(cortex_publish.NewCortexPublisher())
+		publish.Init(cortexPublish.NewCortexPublisher())
 		inputs = append(inputs, carbon.InitCarbon())
 	} else {
 		publish.Init(nil)
@@ -131,7 +131,7 @@ func handleShutdown(done chan struct{}, interrupt chan os.Signal, inputs []Stopp
 
 // InitRoutes initializes the routes.
 func initRoutes(a *api.Api) {
-	a.Router.Any("/api/prom/push", a.PromStats("cortex-write"), a.Auth(), cortex_publish.Write)
+	a.Router.Any("/api/prom/push", a.PromStats("cortex-write"), a.Auth(), cortexPublish.Write)
 	a.Router.Any("/api/prom/*", a.PromStats("cortex-read"), a.Auth(), cortex.Proxy)
 	a.Router.Post("/datadog/api/v1/series", a.Auth(), ingest.DataDogWrite)
 	a.Router.Post("/opentsdb/api/put", a.Auth(), ingest.OpenTSDBWrite)

--- a/cmd/cortex-gw/main.go
+++ b/cmd/cortex-gw/main.go
@@ -24,12 +24,12 @@ import (
 )
 
 var (
-	app                = "cortex-gw"
-	GitHash            = "(none)"
-	showVersion        = flag.Bool("version", false, "print version string")
-	confFile           = flag.String("config", "/etc/gw/cortex-gw.ini", "configuration file path")
-	authPlugin         = flag.String("api-auth-plugin", "grafana-instance", "auth plugin to use. (grafana-instance|file)")
-	cortexWriteEnabled = flag.Bool("cortex-forward-3rdparty", false, "enable writing to cortex with non standard agents")
+	app             = "cortex-gw"
+	GitHash         = "(none)"
+	showVersion     = flag.Bool("version", false, "print version string")
+	confFile        = flag.String("config", "/etc/gw/cortex-gw.ini", "configuration file path")
+	authPlugin      = flag.String("api-auth-plugin", "grafana-instance", "auth plugin to use. (grafana-instance|file)")
+	forward3rdParty = flag.Bool("forward-3rdparty", false, "enable writing to cortex with non standard agents")
 
 	tracingEnabled = flag.Bool("tracing-enabled", false, "enable/disable distributed opentracing via jaeger")
 	tracingAddr    = flag.String("tracing-addr", "localhost:6831", "address of the jaeger agent to send data to")
@@ -69,7 +69,7 @@ func main() {
 
 	var inputs []Stoppable
 
-	if *cortexWriteEnabled {
+	if *forward3rdParty {
 		publish.Init(cortexPublish.NewCortexPublisher())
 		inputs = append(inputs, carbon.InitCarbon())
 	} else {

--- a/cmd/cortex-gw/main.go
+++ b/cmd/cortex-gw/main.go
@@ -29,7 +29,7 @@ var (
 	showVersion        = flag.Bool("version", false, "print version string")
 	confFile           = flag.String("config", "/etc/gw/cortex-gw.ini", "configuration file path")
 	authPlugin         = flag.String("api-auth-plugin", "grafana-instance", "auth plugin to use. (grafana-instance|file)")
-	cortexWriteEnabled = flag.Bool("cortex-publish-enabled", false, "enable writing to cortex with non standard agents")
+	cortexWriteEnabled = flag.Bool("cortex-forward-3rdparty", false, "enable writing to cortex with non standard agents")
 
 	tracingEnabled = flag.Bool("tracing-enabled", false, "enable/disable distributed opentracing via jaeger")
 	tracingAddr    = flag.String("tracing-addr", "localhost:6831", "address of the jaeger agent to send data to")

--- a/cmd/cortex-gw/main.go
+++ b/cmd/cortex-gw/main.go
@@ -133,7 +133,7 @@ func handleShutdown(done chan struct{}, interrupt chan os.Signal, inputs []Stopp
 func initRoutes(a *api.Api) {
 	a.Router.Any("/api/prom/push", a.PromStats("cortex-write"), a.Auth(), cortex_publish.Write)
 	a.Router.Any("/api/prom/*", a.PromStats("cortex-read"), a.Auth(), cortex.Proxy)
-	a.Router.Post("/datadog/api/v1/series", a.Auth(), ingest.DataDogMTWrite)
+	a.Router.Post("/datadog/api/v1/series", a.Auth(), ingest.DataDogWrite)
 	a.Router.Post("/opentsdb/api/put", a.Auth(), ingest.OpenTSDBWrite)
 }
 

--- a/cmd/tsdb-gw/main.go
+++ b/cmd/tsdb-gw/main.go
@@ -168,7 +168,7 @@ func initRoutes(a *api.Api) {
 	a.Router.Any("/prometheus/*", a.Auth(), metrictank.PrometheusProxy)
 	a.Router.Any("/graphite/*", a.Auth(), graphite.GraphiteProxy)
 	a.Router.Post("/metrics", a.Auth(), ingest.Metrics)
-	a.Router.Post("/datadog/api/v1/series", a.Auth(), ingest.DataDogMTWrite)
+	a.Router.Post("/datadog/api/v1/series", a.Auth(), ingest.DataDogWrite)
 	a.Router.Post("/opentsdb/api/put", a.Auth(), ingest.OpenTSDBWrite)
 	a.Router.Any("/prometheus/write", a.Auth(), ingest.PrometheusMTWrite)
 }

--- a/ingest/carbon/carbon.go
+++ b/ingest/carbon/carbon.go
@@ -31,7 +31,6 @@ var (
 
 	Enabled           bool
 	addr              string
-	schemasConf       string
 	concurrency       int
 	bufferSize        int
 	flushInterval     time.Duration
@@ -44,7 +43,6 @@ var (
 func init() {
 	flag.StringVar(&addr, "carbon-addr", "0.0.0.0:2003", "listen address for carbon input")
 	flag.BoolVar(&Enabled, "carbon-enabled", false, "enable carbon input")
-	flag.StringVar(&schemasConf, "schemas-file", "/etc/gw/storage-schemas.conf", "path to carbon storage-schemas.conf file")
 	flag.DurationVar(&flushInterval, "carbon-flush-interval", time.Second, "maximum time between flushs to kafka")
 	flag.IntVar(&concurrency, "carbon-concurrency", 1, "number of goroutines for handling metrics")
 	flag.IntVar(&bufferSize, "carbon-buffer-size", 100000, "number of metrics to hold in an input buffer. Once this buffer fills metrics will be dropped")
@@ -72,12 +70,6 @@ func InitCarbon() *Carbon {
 
 	log.Infof("Carbon input listening on %s", addr)
 	c.buf = make(chan []byte, bufferSize)
-
-	schemas, err := getSchemas(schemasConf)
-	if err != nil {
-		log.Fatalf("failed to load schemas config. %s", err)
-	}
-	c.schemas = schemas
 
 	laddr, err := net.ResolveTCPAddr("tcp", addr)
 	if err != nil {

--- a/ingest/carbon/schemas.go
+++ b/ingest/carbon/schemas.go
@@ -51,11 +51,10 @@ func parseMetric(buf []byte, schemas *conf.Schemas, orgId int) (*schema.MetricDa
 		return nil, fmt.Errorf("can't parse timestamp: %s", err)
 	}
 
-	_, s := schemas.Match(name, 0)
 	md := metricPool.Get()
 	*md = schema.MetricData{
 		Name:     name,
-		Interval: s.Retentions[0].SecondsPerPoint,
+		Interval: 0,
 		Value:    val,
 		Unit:     "unknown",
 		Time:     int64(timestamp),

--- a/ingest/datadog.go
+++ b/ingest/datadog.go
@@ -25,7 +25,7 @@ type DataDogPayload struct {
 	} `json:"series"`
 }
 
-func DataDogMTWrite(ctx *api.Context) {
+func DataDogWrite(ctx *api.Context) {
 	if ctx.Req.Request.Body == nil {
 		ctx.JSON(400, "no data included in request.")
 		return

--- a/ingest/datadog.go
+++ b/ingest/datadog.go
@@ -54,13 +54,12 @@ func DataDogWrite(ctx *api.Context) {
 
 	buf := make([]*schema.MetricData, 0)
 	for _, ts := range series.Series {
-		_, s := schemas.Match(ts.Name, 0)
 		tagSet := createTagSet(ts.Host, ts.Device, ts.Tags)
 		for _, point := range ts.Points {
 			md := metricPool.Get()
 			*md = schema.MetricData{
 				Name:     ts.Name,
-				Interval: s.Retentions[0].SecondsPerPoint,
+				Interval: 0,
 				Value:    point[1],
 				Unit:     "unknown",
 				Time:     int64(point[0]),

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -15,7 +15,7 @@ var (
 	ingestEnabled = flag.Bool("api-ingest", true, "enable api ingest for datadog/opentsdb/prometheus for metrictank")
 )
 
-func IngestInit() {
+func init() {
 	if !*ingestEnabled {
 		return
 	}

--- a/ingest/ingest.go
+++ b/ingest/ingest.go
@@ -1,31 +1,9 @@
 package ingest
 
 import (
-	"flag"
-
-	"github.com/grafana/metrictank/conf"
 	"github.com/raintank/tsdb-gw/util"
-	log "github.com/sirupsen/logrus"
 )
 
 var (
-	metricPool    = util.NewMetricDataPool()
-	schemas       *conf.Schemas
-	schemaFile    = flag.String("api-schemas-file", "/etc/gw/storage-schemas.conf", "path to carbon storage-schemas.conf file")
-	ingestEnabled = flag.Bool("api-ingest", true, "enable api ingest for datadog/opentsdb/prometheus for metrictank")
+	metricPool = util.NewMetricDataPool()
 )
-
-func init() {
-	if !*ingestEnabled {
-		return
-	}
-	log.Info("api ingest enabled")
-	if *schemaFile == "" {
-		log.Fatalln("no schema file configured for api ingest")
-	}
-	s, err := conf.ReadSchemas(*schemaFile)
-	if err != nil {
-		log.Fatalf("failed to load carbon schemas config. %s", err)
-	}
-	schemas = &s
-}

--- a/ingest/opentsdb.go
+++ b/ingest/opentsdb.go
@@ -45,11 +45,10 @@ func OpenTSDBWrite(ctx *api.Context) {
 
 		var buf []*schema.MetricData
 		for _, ts := range req {
-			_, s := schemas.Match(ts.Metric, 0)
 			md := metricPool.Get()
 			*md = schema.MetricData{
 				Name:     ts.Metric,
-				Interval: s.Retentions[0].SecondsPerPoint,
+				Interval: 0,
 				Value:    ts.Value,
 				Unit:     "unknown",
 				Time:     ts.Timestamp,

--- a/ingest/prometheus.go
+++ b/ingest/prometheus.go
@@ -50,13 +50,11 @@ func PrometheusMTWrite(ctx *api.Context) {
 				}
 			}
 			if name != "" {
-				_, s := schemas.Match(name, 0)
-
 				for _, sample := range ts.Samples {
 					md := metricPool.Get()
 					*md = schema.MetricData{
 						Name:     name,
-						Interval: s.Retentions[0].SecondsPerPoint,
+						Interval: 0,
 						Value:    sample.Value,
 						Unit:     "unknown",
 						Time:     (sample.Timestamp / 1000),

--- a/publish/cortex/proxy.go
+++ b/publish/cortex/proxy.go
@@ -1,0 +1,12 @@
+package cortex
+
+import (
+	"strconv"
+
+	"github.com/raintank/tsdb-gw/api"
+)
+
+func Write(c *api.Context) {
+	c.Req.Request.Header.Set("X-Scope-OrgID", strconv.Itoa(c.User.ID))
+	writeProxy.ServeHTTP(c.Resp, c.Req.Request)
+}

--- a/publish/cortex/publish.go
+++ b/publish/cortex/publish.go
@@ -134,7 +134,7 @@ func (c *cortexPublisher) Type() string {
 	return "cortex"
 }
 
-// Store sends a batch of samples to the HTTP endpoint.
+// Write sends a batch of samples to the HTTP endpoint.
 func (c *cortexPublisher) Write(req writeRequest) error {
 	data, err := proto.Marshal(req.Request)
 	if err != nil {

--- a/publish/cortex/publish.go
+++ b/publish/cortex/publish.go
@@ -1,0 +1,136 @@
+package cortex
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/oxtoacart/bpool"
+	"github.com/prometheus/common/config"
+	"github.com/prometheus/prometheus/storage/remote"
+	"github.com/raintank/tsdb-gw/api"
+	schema "gopkg.in/raintank/schema.v1"
+)
+
+var (
+	cortexWriteURL = flag.String("cortex-write-url", "http://localhost:9000", "cortex write address")
+
+	cortexWriteBPoolSize  = flag.Int("cortex-bpool-size", 100, "max number of byte buffers in the cortex write buffer pool")
+	cortexWriteBPoolWidth = flag.Int("cortex-bpool-width", 1024, "capacity of byte array provided by cortex write buffer pool")
+
+	// WriteProxy handles all write requests to cortex
+	writeProxy *httputil.ReverseProxy
+)
+
+const maxErrMsgLen = 256
+
+// Init initializes the cortex reverse proxies
+func init() {
+	CortexWriteURL, err := url.Parse(*cortexWriteURL)
+	if err != nil {
+		log.Fatalf("unable to parse cortex write url '%s': %v", *cortexWriteURL, err)
+	}
+	// Seperate Proxy for Writes, add BufferPool for perf reasons if needed
+	writeProxy = &httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = CortexWriteURL.Scheme
+			req.URL.Host = CortexWriteURL.Host
+		},
+		BufferPool: bpool.NewBytePool(*cortexWriteBPoolSize, *cortexWriteBPoolWidth),
+	}
+}
+
+type cortexPublisher struct {
+	url     *url.URL
+	client  *http.Client
+	timeout time.Duration
+}
+
+func NewCortexPublisher() *cortexPublisher {
+	CortexWriteURL, err := url.Parse(*cortexWriteURL)
+	if err != nil {
+		log.Fatalf("unable to parse cortex write url '%v': %v", *cortexWriteURL, err)
+	}
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			MaxIdleConns:        20000,
+			MaxIdleConnsPerHost: 1000,
+			DisableKeepAlives:   false,
+			DisableCompression:  true,
+			IdleConnTimeout:     5 * time.Minute,
+		},
+	}
+
+	remote.NewClient(0, &remote.ClientConfig{
+		URL: &config.URL{
+			CortexWriteURL,
+		},
+	})
+
+	return &cortexPublisher{
+		url:     CortexWriteURL,
+		client:  httpClient,
+		timeout: time.Second * 60,
+	}
+}
+
+func (c *cortexPublisher) Publish(metrics []*schema.MetricData) error {
+	return nil
+}
+
+func (c *cortexPublisher) Type() string {
+	return "cortex"
+}
+
+func Write(c *api.Context) {
+	c.Req.Request.Header.Set("X-Scope-OrgID", strconv.Itoa(c.User.ID))
+	writeProxy.ServeHTTP(c.Resp, c.Req.Request)
+}
+
+// // Store sends a batch of samples to the HTTP endpoint.
+// func (c *cortexPublisher) Write(req *prompb.WriteRequest) error {
+// 	data, err := proto.Marshal(req)
+// 	if err != nil {
+// 		return err
+// 	}
+
+// 	compressed := snappy.Encode(nil, data)
+// 	httpReq, err := http.NewRequest("POST", c.url.String(), bytes.NewReader(compressed))
+// 	if err != nil {
+// 		// Errors from NewRequest are from unparseable URLs, so are not
+// 		// recoverable.
+// 		return err
+// 	}
+// 	httpReq.Header.Add("Content-Encoding", "snappy")
+// 	httpReq.Header.Set("Content-Type", "application/x-protobuf")
+// 	httpReq.Header.Set("X-Prometheus-Remote-Write-Version", "0.1.0")
+
+// 	ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+// 	defer cancel()
+
+// 	httpResp, err := ctxhttp.Do(ctx, c.client, httpReq)
+// 	if err != nil {
+// 		// Errors from client.Do are from (for example) network errors, so are
+// 		// recoverable.
+// 		return err
+// 	}
+// 	defer httpResp.Body.Close()
+
+// 	if httpResp.StatusCode/100 != 2 {
+// 		scanner := bufio.NewScanner(io.LimitReader(httpResp.Body, maxErrMsgLen))
+// 		line := ""
+// 		if scanner.Scan() {
+// 			line = scanner.Text()
+// 		}
+// 		err = fmt.Errorf("server returned HTTP status %s: %s", httpResp.Status, line)
+// 	}
+// 	if httpResp.StatusCode/100 == 5 {
+// 		return err
+// 	}
+// 	return err
+// }

--- a/publish/cortex/publish.go
+++ b/publish/cortex/publish.go
@@ -135,7 +135,7 @@ func (c *cortexPublisher) Type() string {
 }
 
 // Write sends a batch of samples to the HTTP endpoint.
-func (c *cortexPublisher) Write(req writeRequest) error {
+func (c *cortexPublisher) Write(req *writeRequest) error {
 	data, err := proto.Marshal(req.Request)
 	if err != nil {
 		return err

--- a/publish/cortex/publish_test.go
+++ b/publish/cortex/publish_test.go
@@ -12,7 +12,7 @@ func Test_packageMetrics(t *testing.T) {
 	tests := []struct {
 		name    string
 		metrics []*schema.MetricData
-		want    *writeRequest
+		want    writeRequest
 		wantErr bool
 	}{
 		{
@@ -20,8 +20,8 @@ func Test_packageMetrics(t *testing.T) {
 			metrics: []*schema.MetricData{
 				&schema.MetricData{Name: "example_metric"},
 			},
-			want: &writeRequest{
-				Request: &prompb.WriteRequest{
+			want: writeRequest{
+				Request: prompb.WriteRequest{
 					Timeseries: []*prompb.TimeSeries{
 						&prompb.TimeSeries{
 							Labels: []*prompb.Label{
@@ -41,8 +41,8 @@ func Test_packageMetrics(t *testing.T) {
 			metrics: []*schema.MetricData{
 				&schema.MetricData{Name: "example.metric"},
 			},
-			want: &writeRequest{
-				Request: &prompb.WriteRequest{
+			want: writeRequest{
+				Request: prompb.WriteRequest{
 					Timeseries: []*prompb.TimeSeries{
 						&prompb.TimeSeries{
 							Labels: []*prompb.Label{
@@ -65,8 +65,8 @@ func Test_packageMetrics(t *testing.T) {
 					Tags: []string{"example=tag"},
 				},
 			},
-			want: &writeRequest{
-				Request: &prompb.WriteRequest{
+			want: writeRequest{
+				Request: prompb.WriteRequest{
 					Timeseries: []*prompb.TimeSeries{
 						&prompb.TimeSeries{
 							Labels: []*prompb.Label{
@@ -90,7 +90,7 @@ func Test_packageMetrics(t *testing.T) {
 					Tags: []string{"example="},
 				},
 			},
-			want:    nil,
+			want:    writeRequest{},
 			wantErr: true,
 		},
 		{
@@ -101,8 +101,8 @@ func Test_packageMetrics(t *testing.T) {
 					Tags: []string{"example1=tag", "example2=tag"},
 				},
 			},
-			want: &writeRequest{
-				Request: &prompb.WriteRequest{
+			want: writeRequest{
+				Request: prompb.WriteRequest{
 					Timeseries: []*prompb.TimeSeries{
 						&prompb.TimeSeries{
 							Labels: []*prompb.Label{

--- a/publish/cortex/publish_test.go
+++ b/publish/cortex/publish_test.go
@@ -1,0 +1,128 @@
+package cortex
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/prometheus/prompb"
+	schema "gopkg.in/raintank/schema.v1"
+)
+
+func Test_packageMetrics(t *testing.T) {
+	tests := []struct {
+		name    string
+		metrics []*schema.MetricData
+		want    *prompb.WriteRequest
+		wantErr bool
+	}{
+		{
+			name: "basic metric",
+			metrics: []*schema.MetricData{
+				&schema.MetricData{Name: "example_metric"},
+			},
+			want: &prompb.WriteRequest{
+				Timeseries: []*prompb.TimeSeries{
+					&prompb.TimeSeries{
+						Labels: []*prompb.Label{
+							&prompb.Label{Name: "__name__", Value: "example_metric"},
+						},
+						Samples: []*prompb.Sample{
+							&prompb.Sample{Value: 0, Timestamp: 0},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "graphite metric",
+			metrics: []*schema.MetricData{
+				&schema.MetricData{Name: "example.metric"},
+			},
+			want: &prompb.WriteRequest{
+				Timeseries: []*prompb.TimeSeries{
+					&prompb.TimeSeries{
+						Labels: []*prompb.Label{
+							&prompb.Label{Name: "__name__", Value: "example_metric"},
+						},
+						Samples: []*prompb.Sample{
+							&prompb.Sample{Value: 0, Timestamp: 0},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "tagged metric",
+			metrics: []*schema.MetricData{
+				&schema.MetricData{
+					Name: "example_metric",
+					Tags: []string{"example=tag"},
+				},
+			},
+			want: &prompb.WriteRequest{
+				Timeseries: []*prompb.TimeSeries{
+					&prompb.TimeSeries{
+						Labels: []*prompb.Label{
+							&prompb.Label{Name: "__name__", Value: "example_metric"},
+							&prompb.Label{Name: "example", Value: "tag"},
+						},
+						Samples: []*prompb.Sample{
+							&prompb.Sample{Value: 0, Timestamp: 0},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "bad tagged metric",
+			metrics: []*schema.MetricData{
+				&schema.MetricData{
+					Name: "example_metric",
+					Tags: []string{"example="},
+				},
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "tagged metric",
+			metrics: []*schema.MetricData{
+				&schema.MetricData{
+					Name: "example_metric",
+					Tags: []string{"example1=tag", "example2=tag"},
+				},
+			},
+			want: &prompb.WriteRequest{
+				Timeseries: []*prompb.TimeSeries{
+					&prompb.TimeSeries{
+						Labels: []*prompb.Label{
+							&prompb.Label{Name: "__name__", Value: "example_metric"},
+							&prompb.Label{Name: "example1", Value: "tag"},
+							&prompb.Label{Name: "example2", Value: "tag"},
+						},
+						Samples: []*prompb.Sample{
+							&prompb.Sample{Value: 0, Timestamp: 0},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := packageMetrics(tt.metrics)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("packageMetrics() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("packageMetrics() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/publish/cortex/publish_test.go
+++ b/publish/cortex/publish_test.go
@@ -12,7 +12,7 @@ func Test_packageMetrics(t *testing.T) {
 	tests := []struct {
 		name    string
 		metrics []*schema.MetricData
-		want    *prompb.WriteRequest
+		want    *writeRequest
 		wantErr bool
 	}{
 		{
@@ -20,14 +20,16 @@ func Test_packageMetrics(t *testing.T) {
 			metrics: []*schema.MetricData{
 				&schema.MetricData{Name: "example_metric"},
 			},
-			want: &prompb.WriteRequest{
-				Timeseries: []*prompb.TimeSeries{
-					&prompb.TimeSeries{
-						Labels: []*prompb.Label{
-							&prompb.Label{Name: "__name__", Value: "example_metric"},
-						},
-						Samples: []*prompb.Sample{
-							&prompb.Sample{Value: 0, Timestamp: 0},
+			want: &writeRequest{
+				Request: &prompb.WriteRequest{
+					Timeseries: []*prompb.TimeSeries{
+						&prompb.TimeSeries{
+							Labels: []*prompb.Label{
+								&prompb.Label{Name: "__name__", Value: "example_metric"},
+							},
+							Samples: []*prompb.Sample{
+								&prompb.Sample{Value: 0, Timestamp: 0},
+							},
 						},
 					},
 				},
@@ -39,14 +41,16 @@ func Test_packageMetrics(t *testing.T) {
 			metrics: []*schema.MetricData{
 				&schema.MetricData{Name: "example.metric"},
 			},
-			want: &prompb.WriteRequest{
-				Timeseries: []*prompb.TimeSeries{
-					&prompb.TimeSeries{
-						Labels: []*prompb.Label{
-							&prompb.Label{Name: "__name__", Value: "example_metric"},
-						},
-						Samples: []*prompb.Sample{
-							&prompb.Sample{Value: 0, Timestamp: 0},
+			want: &writeRequest{
+				Request: &prompb.WriteRequest{
+					Timeseries: []*prompb.TimeSeries{
+						&prompb.TimeSeries{
+							Labels: []*prompb.Label{
+								&prompb.Label{Name: "__name__", Value: "example_metric"},
+							},
+							Samples: []*prompb.Sample{
+								&prompb.Sample{Value: 0, Timestamp: 0},
+							},
 						},
 					},
 				},
@@ -61,15 +65,17 @@ func Test_packageMetrics(t *testing.T) {
 					Tags: []string{"example=tag"},
 				},
 			},
-			want: &prompb.WriteRequest{
-				Timeseries: []*prompb.TimeSeries{
-					&prompb.TimeSeries{
-						Labels: []*prompb.Label{
-							&prompb.Label{Name: "__name__", Value: "example_metric"},
-							&prompb.Label{Name: "example", Value: "tag"},
-						},
-						Samples: []*prompb.Sample{
-							&prompb.Sample{Value: 0, Timestamp: 0},
+			want: &writeRequest{
+				Request: &prompb.WriteRequest{
+					Timeseries: []*prompb.TimeSeries{
+						&prompb.TimeSeries{
+							Labels: []*prompb.Label{
+								&prompb.Label{Name: "__name__", Value: "example_metric"},
+								&prompb.Label{Name: "example", Value: "tag"},
+							},
+							Samples: []*prompb.Sample{
+								&prompb.Sample{Value: 0, Timestamp: 0},
+							},
 						},
 					},
 				},
@@ -95,16 +101,18 @@ func Test_packageMetrics(t *testing.T) {
 					Tags: []string{"example1=tag", "example2=tag"},
 				},
 			},
-			want: &prompb.WriteRequest{
-				Timeseries: []*prompb.TimeSeries{
-					&prompb.TimeSeries{
-						Labels: []*prompb.Label{
-							&prompb.Label{Name: "__name__", Value: "example_metric"},
-							&prompb.Label{Name: "example1", Value: "tag"},
-							&prompb.Label{Name: "example2", Value: "tag"},
-						},
-						Samples: []*prompb.Sample{
-							&prompb.Sample{Value: 0, Timestamp: 0},
+			want: &writeRequest{
+				Request: &prompb.WriteRequest{
+					Timeseries: []*prompb.TimeSeries{
+						&prompb.TimeSeries{
+							Labels: []*prompb.Label{
+								&prompb.Label{Name: "__name__", Value: "example_metric"},
+								&prompb.Label{Name: "example1", Value: "tag"},
+								&prompb.Label{Name: "example2", Value: "tag"},
+							},
+							Samples: []*prompb.Sample{
+								&prompb.Sample{Value: 0, Timestamp: 0},
+							},
 						},
 					},
 				},

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -202,9 +202,11 @@ func (m *mtPublisher) Publish(metrics []*schema.MetricData) error {
 	pubMPNO := 0
 
 	for i, metric := range metrics {
-		_, s := m.schemas.Match(metric.Name, 0)
-		metric.Interval = s.Retentions[0].SecondsPerPoint
-		metric.SetId()
+		if metric.Interval == 0 {
+			_, s := m.schemas.Match(metric.Name, 0)
+			metric.Interval = s.Retentions[0].SecondsPerPoint
+			metric.SetId()
+		}
 
 		var data []byte
 		if v2 {

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -9,6 +9,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/metrictank/conf"
+
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	p "github.com/grafana/metrictank/cluster/partitioner"
 	"github.com/grafana/metrictank/stats"
@@ -29,6 +31,8 @@ var (
 	// won't change during runtime and a single instance can be used by many
 	// threads
 	kafkaPartitioner *p.Kafka
+
+	schemasConf string
 
 	publishedMD     = stats.NewCounter32("output.kafka.published.metricdata")
 	publishedMP     = stats.NewCounter32("output.kafka.published.metricpoint")
@@ -57,7 +61,9 @@ var (
 	partitionerPool sync.Pool
 )
 
-type mtPublisher struct{}
+type mtPublisher struct {
+	schemas *conf.Schemas
+}
 
 type Partitioner interface {
 	partition(schema.PartitionedMetric) (int32, []byte, error)
@@ -107,6 +113,8 @@ func init() {
 	flag.BoolVar(&v2Org, "v2-org", true, "encode org-id in messages")
 	flag.DurationVar(&v2StaleThresh, "v2-stale-thresh", 6*time.Hour, "expire keys (and resend MetricData if seen again) if not seen for this much time")
 	flag.DurationVar(&v2PruneInterval, "v2-prune-interval", time.Hour, "check interval for expiring keys")
+
+	flag.StringVar(&schemasConf, "schemas-file", "/etc/gw/storage-schemas.conf", "path to carbon storage-schemas.conf file")
 }
 
 func New(broker string) *mtPublisher {
@@ -114,6 +122,11 @@ func New(broker string) *mtPublisher {
 		return nil
 	}
 	var err error
+
+	schemas, err := getSchemas(schemasConf)
+	if err != nil {
+		log.Fatalf("failed to load schemas config. %s", err)
+	}
 
 	config := kafka.ConfigMap{}
 	config.SetKey("request.required.acks", "all")
@@ -148,7 +161,9 @@ func New(broker string) *mtPublisher {
 	partitionerPool = sync.Pool{
 		New: func() interface{} { return NewPartitioner() },
 	}
-	return &mtPublisher{}
+	return &mtPublisher{
+		schemas: schemas,
+	}
 }
 
 func tryGetMetadata(producer *kafka.Producer, topic string, attempts int) (*kafka.Metadata, error) {
@@ -187,6 +202,10 @@ func (m *mtPublisher) Publish(metrics []*schema.MetricData) error {
 	pubMPNO := 0
 
 	for i, metric := range metrics {
+		_, s := m.schemas.Match(metric.Name, 0)
+		metric.Interval = s.Retentions[0].SecondsPerPoint
+		metric.SetId()
+
 		var data []byte
 		if v2 {
 			var mkey schema.MKey

--- a/publish/kafka/schemas.go
+++ b/publish/kafka/schemas.go
@@ -1,0 +1,13 @@
+package kafka
+
+import (
+	"github.com/grafana/metrictank/conf"
+)
+
+func getSchemas(file string) (*conf.Schemas, error) {
+	schemas, err := conf.ReadSchemas(file)
+	if err != nil {
+		return nil, err
+	}
+	return &schemas, nil
+}

--- a/publish/publish.go
+++ b/publish/publish.go
@@ -27,6 +27,7 @@ func Publish(metrics []*schema.MetricData) error {
 	return publisher.Publish(metrics)
 }
 
+// nullPublisher drops all metrics passed through the publish interface
 type nullPublisher struct{}
 
 func (*nullPublisher) Publish(metrics []*schema.MetricData) error {

--- a/query/cortex/cortex.go
+++ b/query/cortex/cortex.go
@@ -2,27 +2,18 @@ package cortex
 
 import (
 	"flag"
-	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strconv"
 
-	"github.com/oxtoacart/bpool"
 	"github.com/raintank/tsdb-gw/api"
 )
 
 var (
-	cortexWriteURL = flag.String("cortex-write-url", "http://localhost:9000", "cortex write address")
-	cortexReadURL  = flag.String("cortex-read-url", "http://localhost:9000", "cortex read address")
-
-	cortexWriteBPoolSize  = flag.Int("cortex-bpool-size", 100, "max number of byte buffers in the cortex write buffer pool")
-	cortexWriteBPoolWidth = flag.Int("cortex-bpool-width", 1024, "capacity of byte array provided by cortex write buffer pool")
+	cortexReadURL = flag.String("cortex-read-url", "http://localhost:9000", "cortex read address")
 
 	// Proxy handles all non write requests to cortex
 	proxy *httputil.ReverseProxy
-
-	// WriteProxy handles all write requests to cortex
-	writeProxy *httputil.ReverseProxy
 )
 
 // Init initializes the cortex reverse proxies
@@ -34,27 +25,10 @@ func Init() error {
 	}
 	proxy = httputil.NewSingleHostReverseProxy(CortexReadURL)
 
-	CortexWriteURL, err := url.Parse(*cortexWriteURL)
-	if err != nil {
-		return err
-	}
-	// Seperate Proxy for Writes, add BufferPool for perf reasons if needed
-	writeProxy = &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = CortexWriteURL.Scheme
-			req.URL.Host = CortexWriteURL.Host
-		},
-		BufferPool: bpool.NewBytePool(*cortexWriteBPoolSize, *cortexWriteBPoolWidth),
-	}
 	return nil
 }
 
 func Proxy(c *api.Context) {
 	c.Req.Request.Header.Set("X-Scope-OrgID", strconv.Itoa(c.User.ID))
 	proxy.ServeHTTP(c.Resp, c.Req.Request)
-}
-
-func Write(c *api.Context) {
-	c.Req.Request.Header.Set("X-Scope-OrgID", strconv.Itoa(c.User.ID))
-	writeProxy.ServeHTTP(c.Resp, c.Req.Request)
 }

--- a/scripts/config/cortex-gw.ini
+++ b/scripts/config/cortex-gw.ini
@@ -1,5 +1,5 @@
 # cortex-gw config file with default values
-addr = localhost:80
+addr = :80
 admin-key = not_very_secret_key
 log-level = 2
 

--- a/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
+++ b/vendor/golang.org/x/net/context/ctxhttp/ctxhttp.go
@@ -1,0 +1,74 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build go1.7
+
+// Package ctxhttp provides helper functions for performing context-aware HTTP requests.
+package ctxhttp // import "golang.org/x/net/context/ctxhttp"
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+// Do sends an HTTP request with the provided http.Client and returns
+// an HTTP response.
+//
+// If the client is nil, http.DefaultClient is used.
+//
+// The provided ctx must be non-nil. If it is canceled or times out,
+// ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req.WithContext(ctx))
+	// If we got an error, and the context has been canceled,
+	// the context's error is probably more useful.
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		default:
+		}
+	}
+	return resp, err
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}

--- a/vendor/golang.org/x/net/context/ctxhttp/ctxhttp_pre17.go
+++ b/vendor/golang.org/x/net/context/ctxhttp/ctxhttp_pre17.go
@@ -1,0 +1,147 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !go1.7
+
+package ctxhttp // import "golang.org/x/net/context/ctxhttp"
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+)
+
+func nop() {}
+
+var (
+	testHookContextDoneBeforeHeaders = nop
+	testHookDoReturned               = nop
+	testHookDidBodyClose             = nop
+)
+
+// Do sends an HTTP request with the provided http.Client and returns an HTTP response.
+// If the client is nil, http.DefaultClient is used.
+// If the context is canceled or times out, ctx.Err() will be returned.
+func Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	// TODO(djd): Respect any existing value of req.Cancel.
+	cancel := make(chan struct{})
+	req.Cancel = cancel
+
+	type responseAndError struct {
+		resp *http.Response
+		err  error
+	}
+	result := make(chan responseAndError, 1)
+
+	// Make local copies of test hooks closed over by goroutines below.
+	// Prevents data races in tests.
+	testHookDoReturned := testHookDoReturned
+	testHookDidBodyClose := testHookDidBodyClose
+
+	go func() {
+		resp, err := client.Do(req)
+		testHookDoReturned()
+		result <- responseAndError{resp, err}
+	}()
+
+	var resp *http.Response
+
+	select {
+	case <-ctx.Done():
+		testHookContextDoneBeforeHeaders()
+		close(cancel)
+		// Clean up after the goroutine calling client.Do:
+		go func() {
+			if r := <-result; r.resp != nil {
+				testHookDidBodyClose()
+				r.resp.Body.Close()
+			}
+		}()
+		return nil, ctx.Err()
+	case r := <-result:
+		var err error
+		resp, err = r.resp, r.err
+		if err != nil {
+			return resp, err
+		}
+	}
+
+	c := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			close(cancel)
+		case <-c:
+			// The response's Body is closed.
+		}
+	}()
+	resp.Body = &notifyingReader{resp.Body, c}
+
+	return resp, nil
+}
+
+// Get issues a GET request via the Do function.
+func Get(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Head issues a HEAD request via the Do function.
+func Head(ctx context.Context, client *http.Client, url string) (*http.Response, error) {
+	req, err := http.NewRequest("HEAD", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return Do(ctx, client, req)
+}
+
+// Post issues a POST request via the Do function.
+func Post(ctx context.Context, client *http.Client, url string, bodyType string, body io.Reader) (*http.Response, error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", bodyType)
+	return Do(ctx, client, req)
+}
+
+// PostForm issues a POST request via the Do function.
+func PostForm(ctx context.Context, client *http.Client, url string, data url.Values) (*http.Response, error) {
+	return Post(ctx, client, url, "application/x-www-form-urlencoded", strings.NewReader(data.Encode()))
+}
+
+// notifyingReader is an io.ReadCloser that closes the notify channel after
+// Close is called or a Read fails on the underlying ReadCloser.
+type notifyingReader struct {
+	io.ReadCloser
+	notify chan<- struct{}
+}
+
+func (r *notifyingReader) Read(p []byte) (int, error) {
+	n, err := r.ReadCloser.Read(p)
+	if err != nil && r.notify != nil {
+		close(r.notify)
+		r.notify = nil
+	}
+	return n, err
+}
+
+func (r *notifyingReader) Close() error {
+	err := r.ReadCloser.Close()
+	if r.notify != nil {
+		close(r.notify)
+		r.notify = nil
+	}
+	return err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -501,6 +501,12 @@
 			"revisionTime": "2018-02-18T17:15:52Z"
 		},
 		{
+			"checksumSHA1": "WHc3uByvGaMcnSoI21fhzYgbOgg=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb",
+			"revisionTime": "2018-02-18T17:15:52Z"
+		},
+		{
 			"checksumSHA1": "9pU0E/UV32KU6ci2x6BqCPWeseI=",
 			"path": "golang.org/x/net/http2",
 			"revision": "cbe0f9307d0156177f9dd5dc85da1a31abc5f2fb",


### PR DESCRIPTION
this adds a publisher pipeline for cortex so datadog/opentsdb/etc can be written to cortex.


#### Notes
* `.` characters are replaced wholesale on write with `_`
* The publish code could benefit from a metrics queue and some rate limiting features. I'd rather keep it simple at the moment and add performance optimizing features as needed. 