### PR TITLE
only build binary once and use debian images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ jobs:
   build:
     working_directory: /go/src/github.com/raintank/tsdb-gw
     docker:
-      - image: circleci/golang:1.9.3
+      - image: circleci/golang:1.10.1-stretch
     steps:
-      - run: sudo apt-get install libssl-dev openssl libsasl2-2 libsasl2-dev zlib1g-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y libssl-dev openssl libsasl2-2 libsasl2-dev zlib1g-dev
       - checkout
       - run: scripts/build.sh
       - persist_to_workspace:
@@ -16,9 +17,10 @@ jobs:
   test:
     working_directory: /go/src/github.com/raintank/tsdb-gw
     docker:
-      - image: circleci/golang:1.9.3
+      - image: circleci/golang:1.10.1-stretch
     steps:
-      - run: sudo apt-get install libssl-dev openssl libsasl2-2 libsasl2-dev zlib1g-dev
+      - run: sudo apt-get update
+      - run: sudo apt-get install -y libssl-dev openssl libsasl2-2 libsasl2-dev zlib1g-dev
       - checkout
       - run: scripts/tests.sh
       - run: scripts/vendor_health.sh

--- a/cmd/cortex-gw/Dockerfile
+++ b/cmd/cortex-gw/Dockerfile
@@ -1,28 +1,12 @@
-ARG BASE_PATH=/go/src/github.com/raintank/tsdb-gw
-
-# build binaries inside an alpine3.7 container
-FROM golang:1.9.3-alpine3.7 AS build
-ARG BASE_PATH
-
-RUN apk --update add build-base linux-headers openssl-dev cyrus-sasl-dev bash python git
-COPY . $BASE_PATH/
-RUN $BASE_PATH/scripts/build.sh
-
-# now build the production image based on the same alpine version
-# as was used to build the binaries in
-FROM alpine:3.7
+FROM debian:stretch-slim
 LABEL author="Grafana Labs"
-ARG BASE_PATH
-
-RUN apk --update add ca-certificates
-RUN apk add openssl cyrus-sasl
 
 RUN mkdir -p /etc/gw/
 COPY scripts/config/cortex-gw.ini /etc/gw/cortex-gw.ini
 COPY scripts/entrypoint.sh /usr/bin/
 
 # copy the built binaries from the build image
-COPY --from=build $BASE_PATH/build/cortex-gw /usr/bin/cortex-gw
+COPY build/cortex-gw /usr/bin/cortex-gw
 
 EXPOSE 80
 EXPOSE 443

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,30 +1,15 @@
-ARG BASE_PATH=/go/src/github.com/raintank/tsdb-gw
+FROM debian:stretch-slim
 
-# build binaries inside an alpine3.7 container
-FROM golang:1.10.1-alpine3.7 AS build
-ARG BASE_PATH
-
-RUN apk --update add build-base linux-headers openssl-dev cyrus-sasl-dev bash python git
-
-COPY . $BASE_PATH/
-RUN $BASE_PATH/scripts/build.sh
-
-
-# now build the production image based on the same alpine version
-# as was used to build the binaries in
-FROM alpine:3.7
-ARG BASE_PATH
-
-RUN apk --update add ca-certificates
-RUN apk add openssl cyrus-sasl
+RUN apt-get update
+RUN apt-get install -y libssl1.1 libsasl2-2
 
 RUN mkdir -p /etc/gw/
 COPY scripts/config/tsdb-gw.ini /etc/gw/tsdb-gw.ini
 COPY scripts/entrypoint.sh /usr/bin/
 
 # copy the built binaries from the build image
-COPY --from=build $BASE_PATH/build/tsdb-gw /usr/bin/tsdb-gw
-COPY --from=build $BASE_PATH/build/tsdb-usage /usr/bin/tsdb-usage
+COPY build/tsdb-gw /usr/bin/tsdb-gw
+COPY build/tsdb-usage /usr/bin/tsdb-usage
 
 EXPOSE 80
 EXPOSE 443


### PR DESCRIPTION
This is now reusing the binaries. But remember that this will most likely break `scripts/build_docker.sh` on work stations