### PR TITLE
tsdb-usage doesn't need storage-schemas.conf

### DIFF
--- a/cmd/tsdb-gw/main.go
+++ b/cmd/tsdb-gw/main.go
@@ -99,7 +99,7 @@ func main() {
 	}
 	defer traceCloser.Close()
 
-	publisher := kafka.New(*broker)
+	publisher := kafka.New(*broker, true)
 	if publisher == nil {
 		publish.Init(nil)
 	} else {

--- a/cmd/tsdb-usage/main.go
+++ b/cmd/tsdb-usage/main.go
@@ -45,7 +45,7 @@ func main() {
 	glog.Info("tsdb-usage starting up")
 
 	// initialize our publisher that sends metrics to Kafka
-	publish.Init(kafka.New(*broker))
+	publish.Init(kafka.New(*broker, false))
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM)


### PR DESCRIPTION
because it generates all metrics by itself with known interval.

technically, tsdb-gw also only needs a storage-schemas.conf if we have input plugins enabled that don't enforce/know an interval (e.g. if only kafka input is enabled, we don't need it)
, but adding those conditionals to the code seems clumsy and fragile.