### PR TITLE
expose counters as rates as well

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -161,7 +161,7 @@ func (a *Api) DDAuth() macaron.Handler {
 
 type requestStats struct {
 	sync.Mutex
-	responseCounts    map[string]map[int]*stats.Counter32
+	responseCounts    map[string]map[int]*stats.CounterRate32
 	latencyHistograms map[string]*stats.LatencyHistogram15s32
 	sizeMeters        map[string]*stats.Meter32
 }
@@ -171,12 +171,12 @@ func (r *requestStats) PathStatusCount(ctx *models.Context, path string, status 
 	r.Lock()
 	p, ok := r.responseCounts[path]
 	if !ok {
-		p = make(map[int]*stats.Counter32)
+		p = make(map[int]*stats.CounterRate32)
 		r.responseCounts[path] = p
 	}
 	c, ok := p[status]
 	if !ok {
-		c = stats.NewCounter32(metricKey)
+		c = stats.NewCounterRate32(metricKey)
 		p[status] = c
 	}
 	r.Unlock()
@@ -209,7 +209,7 @@ func (r *requestStats) PathSize(ctx *models.Context, path string, size int) {
 // RequestStats returns a middleware that tracks request metrics.
 func RequestStats() macaron.Handler {
 	stats := requestStats{
-		responseCounts:    make(map[string]map[int]*stats.Counter32),
+		responseCounts:    make(map[string]map[int]*stats.CounterRate32),
 		latencyHistograms: make(map[string]*stats.LatencyHistogram15s32),
 		sizeMeters:        make(map[string]*stats.Meter32),
 	}

--- a/ingest/carbon/carbon.go
+++ b/ingest/carbon/carbon.go
@@ -20,12 +20,12 @@ import (
 )
 
 var (
-	metricsReceived          = stats.NewCounter32("metrics.carbon.received")
-	metricsValid             = stats.NewCounter32("metrics.carbon.valid")
-	metricsRejected          = stats.NewCounter32("metrics.carbon.rejected")
-	metricsFailed            = stats.NewCounter32("metrics.carbon.failed")
-	metricsDroppedBufferFull = stats.NewCounter32("metrics.carbon.dropped_buffer_full")
-	metricsDroppedAuthFail   = stats.NewCounter32("metrics.carbon.dropped_auth_fail")
+	metricsReceived          = stats.NewCounterRate32("metrics.carbon.received")
+	metricsValid             = stats.NewCounterRate32("metrics.carbon.valid")
+	metricsRejected          = stats.NewCounterRate32("metrics.carbon.rejected")
+	metricsFailed            = stats.NewCounterRate32("metrics.carbon.failed")
+	metricsDroppedBufferFull = stats.NewCounterRate32("metrics.carbon.dropped_buffer_full")
+	metricsDroppedAuthFail   = stats.NewCounterRate32("metrics.carbon.dropped_auth_fail")
 
 	carbonConnections = stats.NewGauge32("carbon.connections")
 

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -16,8 +16,8 @@ import (
 )
 
 var (
-	metricsValid    = stats.NewCounter32("metrics.http.valid")
-	metricsRejected = stats.NewCounter32("metrics.http.rejected")
+	metricsValid    = stats.NewCounterRate32("metrics.http.valid")
+	metricsRejected = stats.NewCounterRate32("metrics.http.rejected")
 )
 
 func Metrics(ctx *models.Context) {

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -26,13 +26,13 @@ var (
 	partitioner *p.Kafka
 	schemasConf string
 
-	publishedMD     = stats.NewCounter32("output.kafka.published.metricdata")
-	publishedMP     = stats.NewCounter32("output.kafka.published.metricpoint")
-	publishedMPNO   = stats.NewCounter32("output.kafka.published.metricpoint_no_org")
+	publishedMD     = stats.NewCounterRate32("output.kafka.published.metricdata")
+	publishedMP     = stats.NewCounterRate32("output.kafka.published.metricpoint")
+	publishedMPNO   = stats.NewCounterRate32("output.kafka.published.metricpoint_no_org")
 	messagesSize    = stats.NewMeter32("metrics.message_size", false)
 	publishDuration = stats.NewLatencyHistogram15s32("metrics.publish")
-	sendErrProducer = stats.NewCounter32("metrics.send_error.producer")
-	sendErrOther    = stats.NewCounter32("metrics.send_error.other")
+	sendErrProducer = stats.NewCounterRate32("metrics.send_error.producer")
+	sendErrOther    = stats.NewCounterRate32("metrics.send_error.other")
 
 	topic           string
 	codec           string

--- a/vendor/github.com/grafana/metrictank/stats/counterrate32.go
+++ b/vendor/github.com/grafana/metrictank/stats/counterrate32.go
@@ -1,0 +1,50 @@
+package stats
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// CounterRate32 publishes a counter32 as well as a rate32 in seconds
+type CounterRate32 struct {
+	prev  uint32
+	val   uint32
+	since time.Time
+}
+
+func NewCounterRate32(name string) *CounterRate32 {
+	c := CounterRate32{
+		since: time.Now(),
+	}
+	return registry.getOrAdd(name, &c).(*CounterRate32)
+}
+
+func (c *CounterRate32) SetUint32(val uint32) {
+	atomic.StoreUint32(&c.val, val)
+}
+
+func (c *CounterRate32) Inc() {
+	atomic.AddUint32(&c.val, 1)
+}
+
+func (c *CounterRate32) Add(val int) {
+	c.AddUint32(uint32(val))
+}
+
+func (c *CounterRate32) AddUint32(val uint32) {
+	atomic.AddUint32(&c.val, val)
+}
+
+func (c *CounterRate32) Peek() uint32 {
+	return atomic.LoadUint32(&c.val)
+}
+
+func (c *CounterRate32) ReportGraphite(prefix, buf []byte, now time.Time) []byte {
+	val := atomic.LoadUint32(&c.val)
+	buf = WriteUint32(buf, prefix, []byte("counter32"), val, now)
+	buf = WriteFloat64(buf, prefix, []byte("rate32"), float64(val-c.prev)/now.Sub(c.since).Seconds(), now)
+
+	c.prev = val
+	c.since = now
+	return buf
+}


### PR DESCRIPTION
because we like to aggregate across instances.
this makes that easier