### PR TITLE
update vendored graphite stats output

### DIFF
--- a/cmd/tsdb-gw/main.go
+++ b/cmd/tsdb-gw/main.go
@@ -49,6 +49,7 @@ var (
 	statsAddr       = flag.String("stats-addr", "localhost:2003", "graphite address")
 	statsInterval   = flag.Int("stats-interval", 10, "interval in seconds to send statistics")
 	statsBufferSize = flag.Int("stats-buffer-size", 20000, "how many messages (holding all measurements from one interval) to buffer up in case graphite endpoint is unavailable.")
+	statsTimeout    = flag.Duration("stats-timeout", time.Second*10, "timeout after which a write is considered not successful")
 	tracingEnabled  = flag.Bool("tracing-enabled", false, "enable/disable distributed opentracing via jaeger")
 	tracingAddr     = flag.String("tracing-addr", "localhost:6831", "address of the jaeger agent to send data to")
 )
@@ -82,7 +83,7 @@ func main() {
 		stats.NewMemoryReporter()
 		hostname, _ := os.Hostname()
 		prefix := strings.Replace(*statsPrefix, "$hostname", strings.Replace(hostname, ".", "_", -1), -1)
-		stats.NewGraphite(prefix, *statsAddr, *statsInterval, *statsBufferSize)
+		stats.NewGraphite(prefix, *statsAddr, *statsInterval, *statsBufferSize, *statsTimeout)
 	} else {
 		stats.NewDevnull()
 	}

--- a/vendor/github.com/grafana/metrictank/stats/out_graphite.go
+++ b/vendor/github.com/grafana/metrictank/stats/out_graphite.go
@@ -2,7 +2,9 @@ package stats
 
 import (
 	"bytes"
+	"io"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/raintank/worldping-api/pkg/log"
@@ -25,10 +27,11 @@ type Graphite struct {
 	prefix []byte
 	addr   string
 
+	timeout    time.Duration
 	toGraphite chan []byte
 }
 
-func NewGraphite(prefix, addr string, interval int, bufferSize int) {
+func NewGraphite(prefix, addr string, interval, bufferSize int, timeout time.Duration) {
 	if len(prefix) != 0 && prefix[len(prefix)-1] != '.' {
 		prefix = prefix + "."
 	}
@@ -44,6 +47,7 @@ func NewGraphite(prefix, addr string, interval int, bufferSize int) {
 		prefix:     []byte(prefix),
 		addr:       addr,
 		toGraphite: make(chan []byte, bufferSize),
+		timeout:    timeout,
 	}
 	go g.writer()
 	go g.reporter(interval)
@@ -80,31 +84,33 @@ func (g *Graphite) reporter(interval int) {
 }
 
 // writer connects to graphite and submits all pending data to it
-// TODO: conn.Write() returns no error for a while when the remote endpoint is down, the reconnect happens with a delay. this can also cause lost data for a second or two.
 func (g *Graphite) writer() {
 	var conn net.Conn
 	var err error
+	var wg sync.WaitGroup
 
-	assureConn := func() net.Conn {
+	assureConn := func() {
 		connected.Set(conn != nil)
 		for conn == nil {
 			time.Sleep(time.Second)
 			conn, err = net.Dial("tcp", g.addr)
 			if err == nil {
 				log.Info("stats now connected to %s", g.addr)
+				wg.Add(1)
+				go g.checkEOF(conn, &wg)
 			} else {
 				log.Warn("stats dialing %s failed: %s. will retry", g.addr, err.Error())
 			}
 			connected.Set(conn != nil)
 		}
-		return conn
 	}
 
 	for buf := range g.toGraphite {
 		queueItems.Value(len(g.toGraphite))
 		var ok bool
 		for !ok {
-			conn = assureConn()
+			assureConn()
+			conn.SetWriteDeadline(time.Now().Add(g.timeout))
 			pre := time.Now()
 			_, err = conn.Write(buf)
 			if err == nil {
@@ -113,8 +119,38 @@ func (g *Graphite) writer() {
 			} else {
 				log.Warn("stats failed to write to graphite: %s (took %s). will retry...", err, time.Now().Sub(pre))
 				conn.Close()
+				wg.Wait()
 				conn = nil
 			}
+		}
+	}
+}
+
+// normally the remote end should never write anything back
+// but we know when we get EOF that the other end closed the conn
+// if not for this, we can happily write and flush without getting errors (in Go) but getting RST tcp packets back (!)
+// props to Tv` for this trick.
+func (g *Graphite) checkEOF(conn net.Conn, wg *sync.WaitGroup) {
+	defer wg.Done()
+	b := make([]byte, 1024)
+	for {
+		num, err := conn.Read(b)
+		if err == io.EOF {
+			log.Info("Graphite.checkEOF: remote closed conn. closing conn")
+			conn.Close()
+			return
+		}
+
+		// in case the remote behaves badly (out of spec for carbon protocol)
+		if num != 0 {
+			log.Warn("Graphite.checkEOF: read unexpected data from peer: %s\n", b[:num])
+			continue
+		}
+
+		if err != io.EOF {
+			log.Warn("Graphite.checkEOF: %s. closing conn\n", err)
+			conn.Close()
+			return
 		}
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -351,10 +351,10 @@
 			"revisionTime": "2017-08-31T15:46:53Z"
 		},
 		{
-			"checksumSHA1": "CN8+3osIDyJeSOGhRPgeubTw0Bs=",
+			"checksumSHA1": "VB1yhHR9Udh5uHzCCXm+PrMBr/U=",
 			"path": "github.com/grafana/metrictank/stats",
-			"revision": "442188119462913f5a43c93a90453b17397d9202",
-			"revisionTime": "2018-02-16T14:53:10Z"
+			"revision": "b8a746442edf15cc332db55570dee16589edee2e",
+			"revisionTime": "2018-05-28T11:40:37Z"
 		},
 		{
 			"checksumSHA1": "z8tyaX1kWYzQELcDNg/sPZtMnbs=",


### PR DESCRIPTION
also adds a config parameter to tsdb, which allows to define the write timeout