### PR TITLE
better logging and transport for cortex proxy

### DIFF
--- a/publish/cortex/publish.go
+++ b/publish/cortex/publish.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -78,6 +79,14 @@ func Init() {
 		Director: func(req *http.Request) {
 			req.URL.Scheme = cortexURL.Scheme
 			req.URL.Host = cortexURL.Host
+		},
+		Transport: &http.Transport{
+			Dial: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 90 * time.Second,
+			}).Dial,
+			MaxIdleConns:    200,
+			IdleConnTimeout: 90 * time.Second,
 		},
 		BufferPool: bpool.NewBytePool(*writeBPoolSize, *writeBPoolWidth),
 	}

--- a/util/log.go
+++ b/util/log.go
@@ -3,6 +3,7 @@ package util
 import (
 	"flag"
 	"fmt"
+	"log"
 	"runtime"
 	"strings"
 
@@ -30,6 +31,7 @@ func InitLogger() {
 	}
 	logrus.AddHook(&locationHook{})
 	logrus.Infof("log level set to %v", logrus.GetLevel())
+	log.SetOutput(logrus.StandardLogger().Writer())
 }
 
 type locationHook struct{}


### PR DESCRIPTION
This pipes std log output to logrus logger and uses a non default transport for the cortex reverse proxy.