### PR TITLE
Use the same buckets as underlying services

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -29,7 +29,9 @@ var (
 		Namespace: "cortex_gw",
 		Name:      "request_duration_seconds",
 		Help:      "Time (in seconds) spent serving HTTP requests.",
-		Buckets:   prometheus.ExponentialBuckets(.05, 2, 10),
+		// github.com/weaveworks/common/instrument/instrument.DefBuckets
+		// Pulling it in brings a ton of dependencies.
+		Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100},
 	}, []string{"method", "route", "status_code"})
 )
 


### PR DESCRIPTION
Cortex uses different buckets as the gw which causes differences in the histogram numbers.