### PR TITLE
Sarama kafka version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/raintank/tsdb-gw
     docker:
-      - image: circleci/golang:1.10.1
+      - image: circleci/golang:1.11
     steps:
       - checkout
       - run: scripts/build.sh
@@ -15,7 +15,7 @@ jobs:
   test:
     working_directory: /go/src/github.com/raintank/tsdb-gw
     docker:
-      - image: circleci/golang:1.10.1
+      - image: circleci/golang:1.11
     steps:
       - checkout
       - run: scripts/tests.sh

--- a/auth/file.go
+++ b/auth/file.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 func NewFileAuth() *FileAuth {
-	log.Info("loading carbon auth file from %s", filePath)
+	log.Infof("loading carbon auth file from %s", filePath)
 	a := &FileAuth{
 		keys:        make(map[string]*User),
 		instanceMap: make(map[string]int),

--- a/cmd/tsdb-usage/stats.go
+++ b/cmd/tsdb-usage/stats.go
@@ -7,9 +7,9 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/raintank/schema"
 	"github.com/raintank/tsdb-gw/publish"
 	"github.com/raintank/tsdb-gw/usage"
-	"github.com/raintank/schema"
 )
 
 var shardCount = 4
@@ -188,7 +188,7 @@ func shardIndexer(shard int, flushChan chan TsdbStats) {
 					}
 				}
 				if len(stats.ActiveSeries) == 0 {
-					glog.Info("org %d has no active series.", org)
+					glog.Infof("org %d has no active series.", org)
 					delete(idx.Orgs, org)
 				}
 			}

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -69,7 +69,7 @@ func init() {
 	flag.BoolVar(&v2, "v2", true, "enable optimized MetricPoint payload")
 	flag.BoolVar(&v2Org, "v2-org", true, "encode org-id in messages")
 	flag.DurationVar(&v2ClearInterval, "v2-clear-interval", time.Hour, "interval after which we always resend a full MetricData")
-	flag.StringVar(&kafkaVersionStr, "kafka-version", "V0_10_0_0", "Kafka version. All brokers must be this version or newer.")
+	flag.StringVar(&kafkaVersionStr, "kafka-version", "0.10.0.0", "Kafka version in semver format. All brokers must be this version or newer.")
 }
 
 func getCompression(codec string) sarama.CompressionCodec {

--- a/query/graphite/graphite.go
+++ b/query/graphite/graphite.go
@@ -73,7 +73,7 @@ func (t *proxyRetryTransport) RoundTrip(outreq *http.Request) (*http.Response, e
 		}
 
 		if attempts <= 3 {
-			log.Info("graphiteProxy: request to %v failed, will retry: %s", outreq.URL.Host, err)
+			log.Infof("graphiteProxy: request to %v failed, will retry: %s", outreq.URL.Host, err)
 		} else {
 			log.Errorf("graphiteProxy: request to %v failed 3 times. Giving up: %s", outreq.URL.Host, err)
 			break

--- a/scripts/config/tsdb-gw.ini
+++ b/scripts/config/tsdb-gw.ini
@@ -36,6 +36,8 @@ v2 = true
 v2-org = true
 # interval after which we always resend a full MetricData
 v2-clear-interval = 1h
+# Kafka version in semver format. All brokers must be this version or newer
+kafka-version = 0.10.0.0
 
 # logging
 log-level = 2


### PR DESCRIPTION

from  https://github.com/Shopify/sarama/blob/v1.19.0/config.go#L324-L330

```
The version of Kafka that Sarama will assume it is running against.
Defaults to the oldest supported stable version. Since Kafka provides
backwards-compatibility, setting it to a version older than you have
will not break anything, although it may prevent you from using the
latest features. Setting it to a version greater than you are actually
running may lead to random breakage.
```