### PR TITLE
refactor token and instance caches. fixes #130

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -606,6 +606,14 @@
   revision = "6881fee410a5daf86371371f9ad451b95e168b71"
 
 [[projects]]
+  branch = "master"
+  digest = "1:5325f65188f8a9559c8f20d703b2b2684333a5e03515b6c1fbf09ffc710415af"
+  name = "golang.org/x/sync"
+  packages = ["singleflight"]
+  pruneopts = "NUT"
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
+
+[[projects]]
   digest = "1:5676bcdf4687d6daa95eefa77eb053ed722934677159274f40b75193f3e01cb2"
   name = "golang.org/x/sys"
   packages = ["unix"]
@@ -774,6 +782,7 @@
     "github.com/uber/jaeger-client-go/config",
     "github.com/uber/jaeger-client-go/log",
     "golang.org/x/net/context/ctxhttp",
+    "golang.org/x/sync/singleflight",
     "gopkg.in/ini.v1",
     "gopkg.in/macaron.v1",
   ]

--- a/api/api.go
+++ b/api/api.go
@@ -91,6 +91,7 @@ func (a *Api) Start() *Api {
 func (a *Api) Stop() {
 	a.l.Close()
 	<-a.done
+	a.authPlugin.Stop()
 }
 
 func index(ctx *macaron.Context) {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -36,6 +36,7 @@ type User struct {
 type AuthPlugin interface {
 	// Auth returns whether a api_key is a valid and if the user has access to a certain instance
 	Auth(username, password string) (*User, error)
+	Stop()
 }
 
 func GetAuthPlugin(name string) AuthPlugin {

--- a/auth/file.go
+++ b/auth/file.go
@@ -130,3 +130,7 @@ func (a *FileAuth) Auth(instanceID, password string) (*User, error) {
 
 	return user, nil
 }
+
+func (a *FileAuth) Stop() {
+	return
+}

--- a/auth/gcom/auth.go
+++ b/auth/gcom/auth.go
@@ -10,11 +10,16 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	log "github.com/sirupsen/logrus"
 )
+
+func init() {
+	flag.StringVar(&authEndpoint, "auth-endpoint", authEndpoint, "Endpoint to authenticate users on")
+	flag.DurationVar(&cacheTTL, "auth-cache-ttl", cacheTTL, "how long auth responses should be cached")
+	flag.Var(&validOrgIds, "auth-valid-org-id", "restrict authentication to the listed orgId (comma separated list)")
+}
 
 type int64SliceFlag []int64
 
@@ -39,12 +44,8 @@ func (i *int64SliceFlag) String() string {
 }
 
 var (
-	validTTL      = time.Minute * 5
-	invalidTTL    = time.Second * 30
-	authEndpoint  = "https://grafana.com"
-	validOrgIds   = int64SliceFlag{}
-	cache         *AuthCache
-	instanceCache *InstanceAuthCache
+	authEndpoint = "https://grafana.com"
+	validOrgIds  = int64SliceFlag{}
 
 	// global HTTP client.  By sharing the client we can take
 	// advantage of keepalives and re-use connections instead
@@ -65,118 +66,12 @@ var (
 	}
 )
 
-type AuthCache struct {
-	sync.RWMutex
-	items map[string]CacheItem
-}
-
-type CacheItem struct {
-	User       *SignedInUser
-	ExpireTime time.Time
-}
-
-func (a *AuthCache) Get(key string) (*SignedInUser, bool) {
-	a.RLock()
-	defer a.RUnlock()
-	if c, ok := a.items[key]; ok {
-		return c.User, c.ExpireTime.After(time.Now())
-	}
-	return nil, false
-}
-
-func (a *AuthCache) Set(key string, u *SignedInUser, ttl time.Duration) {
-	a.Lock()
-	a.items[key] = CacheItem{
-		User:       u,
-		ExpireTime: time.Now().Add(ttl),
-	}
-	a.Unlock()
-}
-
-func (a *AuthCache) Clear() {
-	a.Lock()
-	a.items = make(map[string]CacheItem)
-	a.Unlock()
-}
-
-type InstanceAuthCache struct {
-	sync.RWMutex
-	items map[string]InstanceCacheItem
-}
-
-type InstanceCacheItem struct {
-	valid      bool
-	ExpireTime time.Time
-}
-
-func (a *InstanceAuthCache) Get(key string) (bool, bool) {
-	a.RLock()
-	defer a.RUnlock()
-	if c, ok := a.items[key]; ok {
-		return c.valid, c.ExpireTime.After(time.Now())
-	}
-	return false, false
-}
-
-func (a *InstanceAuthCache) Set(key string, valid bool, ttl time.Duration) {
-	a.Lock()
-	a.items[key] = InstanceCacheItem{
-		valid:      valid,
-		ExpireTime: time.Now().Add(ttl),
-	}
-	a.Unlock()
-}
-
-func (a *InstanceAuthCache) Clear() {
-	a.Lock()
-	a.items = make(map[string]InstanceCacheItem)
-	a.Unlock()
-}
-
-func init() {
-	flag.StringVar(&authEndpoint, "auth-endpoint", authEndpoint, "Endpoint to authenticate users on")
-	flag.DurationVar(&validTTL, "auth-valid-ttl", validTTL, "how long valid auth responses should be cached")
-	flag.DurationVar(&invalidTTL, "auth-invalid-ttl", invalidTTL, "how long invalid auth responses should be cached")
-	flag.Var(&validOrgIds, "auth-valid-org-id", "restrict authentication to the listed orgId (comma separated list)")
-	cache = &AuthCache{items: make(map[string]CacheItem)}
-	instanceCache = &InstanceAuthCache{items: make(map[string]InstanceCacheItem)}
-}
-
-func Auth(adminKey, keyString string) (*SignedInUser, error) {
-	if keyString == adminKey {
-		return &SignedInUser{
-			Role:    ROLE_ADMIN,
-			OrgId:   1,
-			OrgName: "Admin",
-			OrgSlug: "admin",
-			IsAdmin: true,
-			key:     keyString,
-		}, nil
-	}
-
-	user, cached := cache.Get(keyString)
-	if cached {
-		if user != nil {
-			log.Debugln("Auth: valid key cached")
-			return user, nil
-		}
-		log.Debugln("Auth: invalid key cached")
-		return nil, ErrInvalidApiKey
-	}
-
+func ValidateToken(keyString string) (*SignedInUser, error) {
 	payload := url.Values{}
 	payload.Add("token", keyString)
 
 	res, err := client.PostForm(fmt.Sprintf("%s/api/api-keys/check", authEndpoint), payload)
 	if err != nil {
-		// if we have an expired cached entry for the user, reset the cache expiration and return that
-		// this allows the service to remain available if grafana.net is unreachable
-		if user != nil {
-			log.Debugf("Auth: re-caching validKey response for %d seconds", validTTL/time.Second)
-			cache.Set(keyString, user, validTTL)
-			return user, nil
-		}
-
 		return nil, err
 	}
 
@@ -184,33 +79,21 @@ func Auth(adminKey, keyString string) (*SignedInUser, error) {
 	res.Body.Close()
 
 	if res.StatusCode >= 500 {
-		// if we have an expired cached entry for the user, reset the cache expiration and return that
-		// this allows the service to remain available if grafana.net is unreachable
-		if user != nil {
-			log.Debugf("Auth: re-caching validKey response for %d seconds", validTTL/time.Second)
-			cache.Set(keyString, user, validTTL)
-			return user, nil
-		}
-
-		return nil, err
+		return nil, fmt.Errorf("Auth token could not be validated: %s", res.Status)
 	}
 
 	if res.StatusCode != 200 {
-		// add the invalid key to the cache
-		log.Debugf("Auth: Caching invalidKey response for %d seconds", invalidTTL/time.Second)
-		cache.Set(keyString, nil, invalidTTL)
-
 		return nil, ErrInvalidApiKey
 	}
 
-	user = &SignedInUser{key: keyString}
+	user := &SignedInUser{key: keyString}
 	err = json.Unmarshal(body, user)
 	if err != nil {
 		return nil, err
 	}
 
 	valid := false
-	// keeping it backwards compatible
+
 	if len(validOrgIds) == 0 {
 		valid = true
 	} else {
@@ -227,56 +110,56 @@ func Auth(adminKey, keyString string) (*SignedInUser, error) {
 		return nil, ErrInvalidOrgId
 	}
 
-	// add the user to the cache.
-	log.Debugf("Auth: Caching validKey response for %d seconds", validTTL/time.Second)
-	cache.Set(keyString, user, validTTL)
 	return user, nil
 }
 
-// validate that the signedInUser has a hosted-metrics instance with the
-// passed instanceID.  It is assumed that the instanceID has already been
-// confirmed to be an integer.
-func (u *SignedInUser) CheckInstance(instanceID string) error {
-	instanceSlug := u.OrgSlug + "-" + instanceID
-
-	// check the cache
-	log.Debugln("Auth: Checking cache for instance")
-	valid, cached := instanceCache.Get(instanceSlug)
-	if cached {
-		if valid {
-			log.Debugln("Auth: valid instance key cached")
-			return nil
-		}
-
-		log.Debugln("Auth: invalid instance key cached")
-		return ErrInvalidInstanceID
+func Auth(adminKey, keyString string) (*SignedInUser, error) {
+	if keyString == adminKey {
+		return &SignedInUser{
+			Role:    ROLE_ADMIN,
+			OrgId:   1,
+			OrgName: "Admin",
+			OrgSlug: "admin",
+			IsAdmin: true,
+			key:     keyString,
+		}, nil
 	}
 
+	user, cached := tokenCache.Get(keyString)
+	if cached {
+		if user != nil {
+			log.Debugln("Auth: valid key cached")
+			return user, nil
+		}
+		log.Debugln("Auth: invalid key cached")
+		return nil, ErrInvalidApiKey
+	}
+
+	var err error
+	user, err = ValidateToken(keyString)
+
+	// ErrInvalidApiKey and ErrInvalidOrgId are successful responses so we
+	// dont return them here.  Instead we cache the response so that
+	// if the token is used again we can reject it straight away.
+	if err != nil && err != ErrInvalidApiKey && err != ErrInvalidOrgId {
+		return nil, err
+	}
+
+	// add the user to the cache.
+	tokenCache.Set(keyString, user)
+	return user, err
+}
+
+func ValidateInstance(instanceID, token string) error {
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/api/hosted-metrics/%s", authEndpoint, instanceID), nil)
 	if err != nil {
-		// if we have an expired cached entry for the user, reset the cache expiration and return that
-		// this allows the service to remain available if grafana.net is unreachable
-		if valid {
-			log.Debugf("Auth: re-caching valid instance response for %d seconds", validTTL/time.Second)
-			instanceCache.Set(instanceSlug, true, validTTL)
-			return nil
-		}
-
 		return err
 	}
 
-	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", u.key))
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", token))
 
 	res, err := client.Do(req)
 	if err != nil {
-		// if we have an expired cached entry for the user, reset the cache expiration and return that
-		// this allows the service to remain available if grafana.net is unreachable
-		if valid {
-			log.Debugf("Auth: re-caching valid instance response for %d seconds", validTTL/time.Second)
-			instanceCache.Set(instanceSlug, true, validTTL)
-			return nil
-		}
-
 		return err
 	}
 
@@ -286,21 +169,10 @@ func (u *SignedInUser) CheckInstance(instanceID string) error {
 	log.Debugf("Auth: hosted-metrics response was: %s", body)
 
 	if res.StatusCode >= 500 {
-		// if we have an expired cached entry for the instanceID, reset the cache expiration and return that
-		// this allows the service to remain available if grafana.net is unreachable
-		if valid {
-			log.Debugf("Auth: re-caching valid instance response for %d seconds", validTTL/time.Second)
-			instanceCache.Set(instanceSlug, true, validTTL)
-			return nil
-		}
-
 		return err
 	}
 
-	// add the invalid instance ID to the cache
 	if res.StatusCode != 200 {
-		log.Debugf("Auth: Caching invalid instance ID response for %d seconds", invalidTTL/time.Second)
-		instanceCache.Set(instanceSlug, false, invalidTTL)
 		return ErrInvalidInstanceID
 	}
 
@@ -312,10 +184,38 @@ func (u *SignedInUser) CheckInstance(instanceID string) error {
 
 	if strconv.Itoa(int(instance.ID)) != instanceID {
 		log.Errorf("Auth: instanceID returned from grafana.com doesnt match requested instanceID. %d != %s", instance.ID, instanceID)
-		return fmt.Errorf("instance.ID returned from grafana.com doesnt match requested instanceID")
+		return ErrInvalidInstanceID
 	}
 
-	log.Debugf("Auth: Caching valid instance response for %d seconds", validTTL/time.Second)
-	instanceCache.Set(instanceSlug, true, validTTL)
 	return nil
+}
+
+// validate that the signedInUser has a hosted-metrics instance with the
+// passed instanceID.  It is assumed that the instanceID has already been
+// confirmed to be an integer.
+func (u *SignedInUser) CheckInstance(instanceID string) error {
+	cachekey := fmt.Sprintf("%s:%s", instanceID, u.key)
+	// check the cache
+	log.Debugln("Auth: Checking cache for instance")
+	valid, cached := instanceCache.Get(cachekey)
+	if cached {
+		if valid {
+			log.Debugln("Auth: valid instance key cached")
+			return nil
+		}
+
+		log.Debugln("Auth: invalid instance key cached")
+		return ErrInvalidInstanceID
+	}
+
+	err := ValidateInstance(instanceID, u.key)
+	// ErrInvalidInstanceID responses are successful responses so we
+	// dont return them here.  Instead we cache the response so that
+	// if the token is used again we can reject it straight away.
+	if err != nil && err != ErrInvalidInstanceID {
+		return err
+	}
+
+	instanceCache.Set(cachekey, (err == nil))
+	return err
 }

--- a/auth/gcom/auth_test.go
+++ b/auth/gcom/auth_test.go
@@ -70,6 +70,7 @@ func TestFlags(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
+	cacheTTL = time.Millisecond * 10
 	mockTransport := httpmock.NewMockTransport()
 	client.Transport = mockTransport
 	validOrgIds = int64SliceFlag{}
@@ -210,7 +211,6 @@ func TestAuth(t *testing.T) {
 				return resp, nil
 			},
 		)
-		cacheTTL = time.Millisecond * 10
 
 		// make sure key is cached
 		cuser, valid := tc.Get("bar")
@@ -258,7 +258,6 @@ func TestAuth(t *testing.T) {
 				return resp, nil
 			},
 		)
-		cacheTTL = time.Millisecond * 10
 
 		// make sure key is cached
 		cuser, valid := tc.Get("bar")
@@ -333,7 +332,7 @@ func TestAuth(t *testing.T) {
 func TestCheckInstance(t *testing.T) {
 	mockTransport := httpmock.NewMockTransport()
 	client.Transport = mockTransport
-
+	cacheTTL = time.Millisecond * 10
 	testUser := SignedInUser{
 		Id:        3,
 		OrgName:   "awoods Test",
@@ -426,7 +425,6 @@ func TestCheckInstance(t *testing.T) {
 				return httpmock.NewStringResponse(404, "not found"), nil
 			},
 		)
-		cacheTTL = time.Millisecond * 10
 
 		// make sure key is cached
 		valid, cached := ic.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
@@ -464,7 +462,6 @@ func TestCheckInstance(t *testing.T) {
 				return httpmock.NewStringResponse(404, "not found"), nil
 			},
 		)
-		cacheTTL = time.Millisecond * 10
 
 		// make sure key is cached
 		valid, cached := ic.Get(fmt.Sprintf("%s:%s", "10", testUser.key))

--- a/auth/gcom/auth_test.go
+++ b/auth/gcom/auth_test.go
@@ -238,7 +238,7 @@ func TestAuth(t *testing.T) {
 		mockTransport.Reset()
 	})
 
-	Convey("When token has not been seen for more then cachettl", t, func() {
+	Convey("When token has not been seen for more than cachettl", t, func() {
 		tc := &TokenCache{
 			items: make(map[string]*TokenResp),
 			stop:  make(chan struct{}),
@@ -448,7 +448,7 @@ func TestCheckInstance(t *testing.T) {
 		mockTransport.Reset()
 	})
 
-	Convey("When instance has not been seen for more then cachettl", t, func() {
+	Convey("When instance has not been seen for more than cachettl", t, func() {
 		ic := &InstanceCache{
 			items: make(map[string]*InstanceResp),
 			stop:  make(chan struct{}),

--- a/auth/gcom/auth_test.go
+++ b/auth/gcom/auth_test.go
@@ -83,6 +83,8 @@ func TestAuth(t *testing.T) {
 		key:       "foo",
 	}
 
+	tokenCache = &TokenCache{items: make(map[string]*TokenResp)}
+
 	Convey("When authenticating with adminKey", t, func() {
 		user, err := Auth("key", "key")
 		So(err, ShouldBeNil)
@@ -109,7 +111,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	Convey("When authenticating using cache", t, func() {
-		cache.Set("foo", &testUser, time.Second)
+		tokenCache.Set("foo", &testUser)
 		mockTransport.RegisterNoResponder(func(req *http.Request) (*http.Response, error) {
 			t.Fatalf("unexpected request made. %s %s", req.Method, req.URL.String())
 			return nil, nil
@@ -126,7 +128,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	Convey("When authenticating with invalid org id 1", t, func() {
-		cache.Clear()
+		tokenCache.Clear()
 		responder, err := httpmock.NewJsonResponder(200, &testUser)
 		So(err, ShouldBeNil)
 		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check", responder)
@@ -142,7 +144,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	Convey("When authenticating with invalid org id 2", t, func() {
-		cache.Clear()
+		tokenCache.Clear()
 		responder, err := httpmock.NewJsonResponder(200, &testUser)
 		So(err, ShouldBeNil)
 		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check", responder)
@@ -158,7 +160,7 @@ func TestAuth(t *testing.T) {
 	})
 
 	Convey("When authenticating with explicitely valid org id", t, func() {
-		cache.Clear()
+		tokenCache.Clear()
 		responder, err := httpmock.NewJsonResponder(200, &testUser)
 		So(err, ShouldBeNil)
 		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check", responder)
@@ -178,86 +180,103 @@ func TestAuth(t *testing.T) {
 		mockTransport.Reset()
 	})
 
-	Convey("When authenticating using expired cache", t, func() {
-		cache.Set("bar", &testUser, 0)
-		responder, err := httpmock.NewJsonResponder(200, &testUser)
-		So(err, ShouldBeNil)
-		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check", responder)
+	Convey("When cached entry is expired", t, func() {
+		tc := &TokenCache{
+			items: make(map[string]*TokenResp),
+			stop:  make(chan struct{}),
+		}
+		tc.Set("bar", &testUser)
+		newUser := SignedInUser{
+			Id:        3,
+			OrgName:   "foo",
+			OrgSlug:   "foo",
+			OrgId:     2,
+			Name:      "foo",
+			Role:      ROLE_EDITOR,
+			CreatedAt: time.Now(),
+			key:       "bar",
+		}
+		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check",
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(200, &newUser)
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				go func() {
+					time.Sleep(time.Millisecond)
+					close(tc.stop)
+				}()
+				return resp, nil
+			},
+		)
+		cacheTTL = time.Millisecond * 10
 
-		// make sure cached item is expired.
-		cuser, valid := cache.Get("bar")
-		So(cuser, ShouldNotBeNil)
-		So(valid, ShouldBeFalse)
-
-		user, err := Auth("key", "bar")
-		So(err, ShouldBeNil)
-		So(user.Role, ShouldEqual, testUser.Role)
-		So(user.OrgId, ShouldEqual, testUser.OrgId)
-		So(user.OrgName, ShouldEqual, testUser.OrgName)
-		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
-		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
-		So(user.key, ShouldEqual, "bar")
-
-		// make sure cache is now updated.
-		cuser, valid = cache.Get("bar")
+		// make sure key is cached
+		cuser, valid := tc.Get("bar")
 		So(cuser, ShouldNotBeNil)
 		So(valid, ShouldBeTrue)
 
+		// start background task to reValidate our token
+		go tc.backgroundValidation()
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for token to be revalidated")
+		case <-tc.stop:
+		}
+
+		// make sure cache is now updated.
+		user, valid := tc.Get("bar")
+		So(user, ShouldNotBeNil)
+		So(valid, ShouldBeTrue)
+		So(user.Role, ShouldEqual, newUser.Role)
+		So(user.OrgId, ShouldEqual, newUser.OrgId)
+		So(user.OrgName, ShouldEqual, newUser.OrgName)
+		So(user.OrgSlug, ShouldEqual, newUser.OrgSlug)
+		So(user.IsAdmin, ShouldEqual, newUser.IsAdmin)
+		So(user.key, ShouldEqual, newUser.key)
 		mockTransport.Reset()
 	})
 
-	Convey("When authenticating using expired cache and bad g.net response", t, func() {
-		cache.Set("baz", &testUser, 0)
-		responder, err := httpmock.NewJsonResponder(503, nil)
-		So(err, ShouldBeNil)
-		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check", responder)
+	Convey("When token has not been seen for more then cachettl", t, func() {
+		tc := &TokenCache{
+			items: make(map[string]*TokenResp),
+			stop:  make(chan struct{}),
+		}
+		tc.Set("bar", &testUser)
+		tokenCache.stop = make(chan struct{})
+		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check",
+			func(req *http.Request) (*http.Response, error) {
+				resp, err := httpmock.NewJsonResponse(200, &testUser)
+				if err != nil {
+					return httpmock.NewStringResponse(500, ""), nil
+				}
+				go func() {
+					time.Sleep(time.Millisecond)
+					close(tc.stop)
+				}()
+				return resp, nil
+			},
+		)
+		cacheTTL = time.Millisecond * 10
 
-		// make sure cached item is expired.
-		cuser, valid := cache.Get("baz")
-		So(cuser, ShouldNotBeNil)
-		So(valid, ShouldBeFalse)
-
-		user, err := Auth("key", "baz")
-		So(err, ShouldBeNil)
-		So(user.Role, ShouldEqual, testUser.Role)
-		So(user.OrgId, ShouldEqual, testUser.OrgId)
-		So(user.OrgName, ShouldEqual, testUser.OrgName)
-		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
-		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
-		So(user.key, ShouldEqual, testUser.key)
-
-		// make sure cache is now updated.
-		cuser, valid = cache.Get("baz")
-		So(cuser, ShouldNotBeNil)
-		So(valid, ShouldBeTrue)
-
-		mockTransport.Reset()
-	})
-	Convey("When authenticating using expired cache and no g.net response", t, func() {
-		cache.Set("baz", &testUser, 0)
-		mockTransport.RegisterResponder("POST", "https://grafana.com/api/api-keys/check", func(req *http.Request) (*http.Response, error) {
-			return nil, fmt.Errorf("failed")
-		})
-
-		// make sure cached item is expired.
-		cuser, valid := cache.Get("baz")
-		So(cuser, ShouldNotBeNil)
-		So(valid, ShouldBeFalse)
-
-		user, err := Auth("key", "baz")
-		So(err, ShouldBeNil)
-		So(user.Role, ShouldEqual, testUser.Role)
-		So(user.OrgId, ShouldEqual, testUser.OrgId)
-		So(user.OrgName, ShouldEqual, testUser.OrgName)
-		So(user.OrgSlug, ShouldEqual, testUser.OrgSlug)
-		So(user.IsAdmin, ShouldEqual, testUser.IsAdmin)
-		So(user.key, ShouldEqual, testUser.key)
-
-		// make sure cache is now updated.
-		cuser, valid = cache.Get("baz")
+		// make sure key is cached
+		cuser, valid := tc.Get("bar")
 		So(cuser, ShouldNotBeNil)
 		So(valid, ShouldBeTrue)
 
+		tc.items["bar"].lastRead = 0
+
+		// start background task to purge our token
+		go tc.backgroundValidation()
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for token to be revalidated")
+		case <-tc.stop:
+		}
+
+		user, valid := tc.Get("bar")
+		So(user, ShouldBeNil)
+		So(valid, ShouldBeFalse)
 		mockTransport.Reset()
 	})
 
@@ -283,14 +302,26 @@ func TestCheckInstance(t *testing.T) {
 		OrgID: 3,
 	}
 
+	tokenCache = &TokenCache{items: make(map[string]*TokenResp)}
+	instanceCache = &InstanceCache{items: make(map[string]*InstanceResp)}
+
 	Convey("when checking valid instanceID", t, func() {
 		responder, err := httpmock.NewJsonResponder(200, &testInstance)
 		So(err, ShouldBeNil)
 		mockTransport.RegisterResponder("GET", "https://grafana.com/api/hosted-metrics/10", responder)
+		instanceCache.Clear()
+		// instance should not be cached.
+		valid, cached := instanceCache.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
+		So(valid, ShouldBeFalse)
+		So(cached, ShouldBeFalse)
 
 		err = testUser.CheckInstance("10")
 		So(err, ShouldBeNil)
 		mockTransport.Reset()
+
+		valid, cached = instanceCache.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
+		So(valid, ShouldBeTrue)
+		So(cached, ShouldBeTrue)
 	})
 
 	Convey("when checking cached valid instanceID", t, func() {
@@ -298,18 +329,18 @@ func TestCheckInstance(t *testing.T) {
 		So(err, ShouldBeNil)
 		mockTransport.RegisterResponder("GET", "https://grafana.com/api/hosted-metrics/10", responder)
 
-		instanceCache.Set("awoodsTest-10", true, time.Second)
+		instanceCache.Set(fmt.Sprintf("%s:%s", "10", testUser.key), true)
 		err = testUser.CheckInstance("10")
 		So(err, ShouldEqual, nil)
 		mockTransport.Reset()
 	})
-	Convey("when checking valid instanceID with expired cache and g.com is down", t, func() {
+	Convey("when checking instanceID and g.com is down", t, func() {
 		mockTransport.RegisterResponder("GET", "https://grafana.com/api/hosted-metrics/10", func(req *http.Request) (*http.Response, error) {
 			return nil, fmt.Errorf("failed")
 		})
-		instanceCache.Set("awoodsTest-10", true, 0)
+		instanceCache.Clear()
 		err := testUser.CheckInstance("10")
-		So(err, ShouldEqual, nil)
+		So(err.Error(), ShouldEqual, "Get https://grafana.com/api/hosted-metrics/10: failed")
 		mockTransport.Reset()
 	})
 	Convey("when checking invalid instanceID", t, func() {
@@ -321,4 +352,92 @@ func TestCheckInstance(t *testing.T) {
 		So(err, ShouldEqual, ErrInvalidInstanceID)
 		mockTransport.Reset()
 	})
+	Convey("when checking cached invalid instanceID", t, func() {
+		responder, err := httpmock.NewJsonResponder(500, "err")
+		So(err, ShouldBeNil)
+		mockTransport.RegisterResponder("GET", "https://grafana.com/api/hosted-metrics/20", responder)
+		instanceCache.Set(fmt.Sprintf("%s:%s", "20", testUser.key), false)
+		err = testUser.CheckInstance("20")
+		So(err, ShouldEqual, ErrInvalidInstanceID)
+		mockTransport.Reset()
+	})
+
+	Convey("When cached entry is expired", t, func() {
+		ic := &InstanceCache{
+			items: make(map[string]*InstanceResp),
+			stop:  make(chan struct{}),
+		}
+		ic.Set(fmt.Sprintf("%s:%s", "10", testUser.key), true)
+
+		mockTransport.RegisterResponder("GET", "https://grafana.com/api/hosted-metrics/10",
+			func(req *http.Request) (*http.Response, error) {
+				go func() {
+					time.Sleep(time.Millisecond)
+					close(ic.stop)
+				}()
+				return httpmock.NewStringResponse(404, "not found"), nil
+			},
+		)
+		cacheTTL = time.Millisecond * 10
+
+		// make sure key is cached
+		valid, cached := ic.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
+		So(valid, ShouldBeTrue)
+		So(cached, ShouldBeTrue)
+
+		// start background task to reValidate our token
+		go ic.backgroundValidation()
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for token to be revalidated")
+		case <-ic.stop:
+		}
+
+		// make sure cache is now updated.
+		valid, cached = ic.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
+		So(valid, ShouldBeFalse)
+		So(cached, ShouldBeTrue)
+		mockTransport.Reset()
+	})
+
+	Convey("When instance has not been seen for more then cachettl", t, func() {
+		ic := &InstanceCache{
+			items: make(map[string]*InstanceResp),
+			stop:  make(chan struct{}),
+		}
+		ic.Set(fmt.Sprintf("%s:%s", "10", testUser.key), true)
+
+		mockTransport.RegisterResponder("GET", "https://grafana.com/api/hosted-metrics/10",
+			func(req *http.Request) (*http.Response, error) {
+				go func() {
+					time.Sleep(time.Millisecond)
+					close(ic.stop)
+				}()
+				return httpmock.NewStringResponse(404, "not found"), nil
+			},
+		)
+		cacheTTL = time.Millisecond * 10
+
+		// make sure key is cached
+		valid, cached := ic.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
+		So(valid, ShouldBeTrue)
+		So(cached, ShouldBeTrue)
+
+		ic.items[fmt.Sprintf("%s:%s", "10", testUser.key)].lastRead = 0
+
+		// start background task to purge our token
+		go ic.backgroundValidation()
+		select {
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for token to be revalidated")
+		case <-ic.stop:
+		}
+
+		valid, cached = ic.Get(fmt.Sprintf("%s:%s", "10", testUser.key))
+		So(valid, ShouldBeFalse)
+		So(cached, ShouldBeFalse)
+
+		mockTransport.Reset()
+	})
+
 }

--- a/auth/gcom/cache.go
+++ b/auth/gcom/cache.go
@@ -1,0 +1,248 @@
+package gcom
+
+import (
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	cacheTTL      = time.Hour
+	tokenCache    *TokenCache
+	instanceCache *InstanceCache
+)
+
+func InitTokenCache() {
+	if tokenCache == nil {
+		tokenCache = &TokenCache{
+			items: make(map[string]*TokenResp),
+			stop:  make(chan struct{}),
+		}
+		go tokenCache.backgroundValidation()
+	}
+}
+
+func StopTokenCache() {
+	close(tokenCache.stop)
+}
+
+func InitInstanceCache() {
+	if instanceCache == nil {
+		instanceCache = &InstanceCache{
+			items: make(map[string]*InstanceResp),
+			stop:  make(chan struct{}),
+		}
+		go instanceCache.backgroundValidation()
+	}
+}
+
+func StopInstanceCache() {
+	close(instanceCache.stop)
+}
+
+type TokenCache struct {
+	sync.RWMutex
+	items map[string]*TokenResp
+	stop  chan struct{}
+}
+
+type TokenResp struct {
+	User      *SignedInUser
+	retrieved time.Time
+	lastRead  int64
+}
+
+func (c *TokenCache) Get(key string) (*SignedInUser, bool) {
+	var user *SignedInUser
+	c.RLock()
+	i, ok := c.items[key]
+	if ok {
+		atomic.StoreInt64(&i.lastRead, time.Now().Unix())
+		user = i.User
+	}
+	c.RUnlock()
+	return user, ok
+}
+
+func (c *TokenCache) Set(key string, u *SignedInUser) {
+	log.Debugf("Auth: Caching token validation response for %s", cacheTTL.String())
+	now := time.Now()
+	c.Lock()
+	c.items[key] = &TokenResp{
+		User:      u,
+		retrieved: now,
+		lastRead:  now.Unix(),
+	}
+	c.Unlock()
+}
+
+func (c *TokenCache) Clear() {
+	c.Lock()
+	c.items = make(map[string]*TokenResp)
+	c.Unlock()
+}
+
+func (c *TokenCache) backgroundValidation() {
+	ticker := time.NewTicker(cacheTTL / 2)
+	for {
+		select {
+		case <-c.stop:
+			return
+		case t := <-ticker.C:
+			c.validate(t)
+		}
+	}
+}
+
+func (c *TokenCache) validate(now time.Time) {
+	oldestAllowed := now.Add(-1 * cacheTTL)
+	// We want to hold the ReadLock for as short a time as possible,
+	// so we lock then get all of the keys in the cache in one go.
+	c.RLock()
+	var keys []string
+	for k, v := range c.items {
+		// if we are past our expiryTime we want this item.
+		if v.retrieved.Before(oldestAllowed) {
+			keys = append(keys, k)
+		}
+	}
+	c.RUnlock()
+
+	for _, k := range keys {
+		user, err := ValidateToken(k)
+		if err != nil && err != ErrInvalidApiKey {
+			// we failed to validate the token.  Grafana.com might be down.
+			// The current TokenResp is kept, and we will try to validate it
+			// again in (cacheTTL/2)
+			log.Warnf("Could not validate token. %s", err)
+			continue
+		}
+		c.Lock()
+		v, ok := c.items[k]
+		if !ok {
+			// this can only happen if a.Clear() was called after releasing the
+			// ReadLock and before acquiring the writeLock
+			c.Unlock()
+			continue
+		}
+
+		// if lastRead is older then retrieved then this key has not been used
+		// since it was last validated, so we should drop it from the cache.
+		// we dont need to use atomic.LoadInt64 for lastRead as we are already holding
+		// a writeLock
+		if v.lastRead < v.retrieved.Unix() {
+			delete(c.items, k)
+			c.Unlock()
+			continue
+		}
+
+		v.retrieved = now
+		v.User = user
+		c.Unlock()
+	}
+}
+
+type InstanceCache struct {
+	sync.RWMutex
+	items map[string]*InstanceResp
+	stop  chan struct{}
+}
+
+type InstanceResp struct {
+	valid     bool
+	retrieved time.Time
+	lastRead  int64
+}
+
+func (c *InstanceCache) Get(key string) (bool, bool) {
+	c.RLock()
+	i, ok := c.items[key]
+	if ok {
+		atomic.StoreInt64(&i.lastRead, time.Now().Unix())
+	}
+	valid := false
+	if ok {
+		valid = i.valid
+	}
+	c.RUnlock()
+	return valid, ok
+}
+
+func (c *InstanceCache) Set(key string, valid bool) {
+	now := time.Now()
+	c.Lock()
+	c.items[key] = &InstanceResp{
+		valid:     valid,
+		retrieved: now,
+		lastRead:  now.Unix(),
+	}
+	c.Unlock()
+}
+
+func (c *InstanceCache) Clear() {
+	c.Lock()
+	c.items = make(map[string]*InstanceResp)
+	c.Unlock()
+}
+
+func (c *InstanceCache) backgroundValidation() {
+	ticker := time.NewTicker(cacheTTL / 2)
+	for {
+		select {
+		case <-c.stop:
+			return
+		case t := <-ticker.C:
+			c.validate(t)
+		}
+	}
+}
+
+func (c *InstanceCache) validate(now time.Time) {
+	oldestAllowed := now.Add(-1 * cacheTTL)
+	// We want to hold the ReadLock for as short a time as possible,
+	// so we lock, then get all of the keys in the cache.
+	c.RLock()
+	var keys []string
+	for k, v := range c.items {
+		// if we are past our expiryTime we want this item.
+		if v.retrieved.Before(oldestAllowed) {
+			keys = append(keys, k)
+		}
+	}
+	c.RUnlock()
+
+	for _, k := range keys {
+		idKey := strings.SplitN(k, ":", 2)
+		err := ValidateInstance(idKey[0], idKey[1])
+		if err != nil && err != ErrInvalidInstanceID {
+			// we failed to validate the token.  Grafana.com might be down.
+			// The current TokenResp is kept, and we will try to validate it
+			// again in (cacheTTL/2)
+			log.Warnf("Could not validate instanceID. %s", err)
+			continue
+		}
+		c.Lock()
+		v, ok := c.items[k]
+		if !ok {
+			// this can only happen if a.Clear() was called after releasing the
+			// ReadLock and before acquiring the writeLock
+			c.Unlock()
+			continue
+		}
+
+		// if lastRead is older then retrieved then this key has not been used
+		// since it was last validated, so we should drop it from the cache
+		if v.lastRead < v.retrieved.Unix() {
+			delete(c.items, k)
+			c.Unlock()
+			continue
+		}
+
+		v.retrieved = now
+		v.valid = (err == nil)
+		c.Unlock()
+	}
+}

--- a/auth/gcom/cache.go
+++ b/auth/gcom/cache.go
@@ -99,7 +99,7 @@ func (c *TokenCache) backgroundValidation() {
 func (c *TokenCache) validate(now time.Time) {
 	oldestAllowed := now.Add(-1 * cacheTTL)
 	// We want to hold the ReadLock for as short a time as possible,
-	// so we lock then get all of the keys in the cache in one go.
+	// so we lock, then get all of the keys in the cache in one go.
 	c.RLock()
 	var keys []string
 	for k, v := range c.items {
@@ -128,7 +128,7 @@ func (c *TokenCache) validate(now time.Time) {
 			continue
 		}
 
-		// if lastRead is older then retrieved then this key has not been used
+		// if lastRead is older than retrieved, then this key has not been used
 		// since it was last validated, so we should drop it from the cache.
 		// we dont need to use atomic.LoadInt64 for lastRead as we are already holding
 		// a writeLock
@@ -231,7 +231,7 @@ func (c *InstanceCache) validate(now time.Time) {
 			continue
 		}
 
-		// if lastRead is older then retrieved then this key has not been used
+		// if lastRead is older than retrieved, then this key has not been used
 		// since it was last validated, so we should drop it from the cache
 		if v.lastRead < v.retrieved.Unix() {
 			delete(c.items, k)

--- a/auth/gcom/cache.go
+++ b/auth/gcom/cache.go
@@ -1,7 +1,6 @@
 package gcom
 
 import (
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -215,8 +214,7 @@ func (c *InstanceCache) validate(now time.Time) {
 	c.RUnlock()
 
 	for _, k := range keys {
-		idKey := strings.SplitN(k, ":", 2)
-		err := ValidateInstance(idKey[0], idKey[1])
+		err := ValidateInstance(k)
 		if err != nil && err != ErrInvalidInstanceID {
 			// we failed to validate the token.  Grafana.com might be down.
 			// The current TokenResp is kept, and we will try to validate it

--- a/auth/grafana-com.go
+++ b/auth/grafana-com.go
@@ -7,6 +7,7 @@ import (
 type GrafanaComAuth struct{}
 
 func NewGrafanaComAuth() *GrafanaComAuth {
+	gcom.InitTokenCache()
 	return &GrafanaComAuth{}
 }
 
@@ -30,4 +31,9 @@ func (a *GrafanaComAuth) Auth(username, password string) (*User, error) {
 		IsAdmin: u.IsAdmin,
 		Role:    u.Role,
 	}, nil
+}
+
+func (a *GrafanaComAuth) Stop() {
+	gcom.StopTokenCache()
+	gcom.StopInstanceCache()
 }

--- a/auth/grafana_com_instance.go
+++ b/auth/grafana_com_instance.go
@@ -10,6 +10,8 @@ import (
 type GrafanaComInstanceAuth struct{}
 
 func NewGrafanaComInstanceAuth() *GrafanaComInstanceAuth {
+	gcom.InitTokenCache()
+	gcom.InitInstanceCache()
 	return &GrafanaComInstanceAuth{}
 }
 
@@ -46,4 +48,9 @@ func (a *GrafanaComInstanceAuth) Auth(username, password string) (*User, error) 
 		IsAdmin: u.IsAdmin,
 		Role:    u.Role,
 	}, nil
+}
+
+func (a *GrafanaComInstanceAuth) Stop() {
+	gcom.StopTokenCache()
+	gcom.StopInstanceCache()
 }

--- a/scripts/config/cortex-gw.ini
+++ b/scripts/config/cortex-gw.ini
@@ -6,9 +6,8 @@ log-level = 2
 api-auth-plugin = grafana-instance
 auth-endpoint = https://grafana.com
 auth-file-path = /etc/gw/auth.ini
-auth-invalid-ttl = 30s
+auth-cache-ttl = 1h
 auth-valid-org-id = ,
-auth-valid-ttl = 5m0s
 
 bpool-size = 100
 bpool-width = 1024

--- a/scripts/config/tsdb-gw.ini
+++ b/scripts/config/tsdb-gw.ini
@@ -4,6 +4,8 @@ metrictank-url = http://localhost:6060
 # auth
 auth-file-path = /etc/gw/auth.ini
 admin-key = not_very_secret_key
+auth-cache-ttl = 1h
+auth-endpoint = https://grafana.com
 
 # api
 addr = :80

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/singleflight/singleflight.go
+++ b/vendor/golang.org/x/sync/singleflight/singleflight.go
@@ -1,0 +1,111 @@
+// Copyright 2013 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package singleflight provides a duplicate function call suppression
+// mechanism.
+package singleflight // import "golang.org/x/sync/singleflight"
+
+import "sync"
+
+// call is an in-flight or completed singleflight.Do call
+type call struct {
+	wg sync.WaitGroup
+
+	// These fields are written once before the WaitGroup is done
+	// and are only read after the WaitGroup is done.
+	val interface{}
+	err error
+
+	// These fields are read and written with the singleflight
+	// mutex held before the WaitGroup is done, and are read but
+	// not written after the WaitGroup is done.
+	dups  int
+	chans []chan<- Result
+}
+
+// Group represents a class of work and forms a namespace in
+// which units of work can be executed with duplicate suppression.
+type Group struct {
+	mu sync.Mutex       // protects m
+	m  map[string]*call // lazily initialized
+}
+
+// Result holds the results of Do, so they can be passed
+// on a channel.
+type Result struct {
+	Val    interface{}
+	Err    error
+	Shared bool
+}
+
+// Do executes and returns the results of the given function, making
+// sure that only one execution is in-flight for a given key at a
+// time. If a duplicate comes in, the duplicate caller waits for the
+// original to complete and receives the same results.
+// The return value shared indicates whether v was given to multiple callers.
+func (g *Group) Do(key string, fn func() (interface{}, error)) (v interface{}, err error, shared bool) {
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		g.mu.Unlock()
+		c.wg.Wait()
+		return c.val, c.err, true
+	}
+	c := new(call)
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	g.doCall(c, key, fn)
+	return c.val, c.err, c.dups > 0
+}
+
+// DoChan is like Do but returns a channel that will receive the
+// results when they are ready.
+func (g *Group) DoChan(key string, fn func() (interface{}, error)) <-chan Result {
+	ch := make(chan Result, 1)
+	g.mu.Lock()
+	if g.m == nil {
+		g.m = make(map[string]*call)
+	}
+	if c, ok := g.m[key]; ok {
+		c.dups++
+		c.chans = append(c.chans, ch)
+		g.mu.Unlock()
+		return ch
+	}
+	c := &call{chans: []chan<- Result{ch}}
+	c.wg.Add(1)
+	g.m[key] = c
+	g.mu.Unlock()
+
+	go g.doCall(c, key, fn)
+
+	return ch
+}
+
+// doCall handles the single call for a key.
+func (g *Group) doCall(c *call, key string, fn func() (interface{}, error)) {
+	c.val, c.err = fn()
+	c.wg.Done()
+
+	g.mu.Lock()
+	delete(g.m, key)
+	for _, ch := range c.chans {
+		ch <- Result{c.val, c.err, c.dups > 0}
+	}
+	g.mu.Unlock()
+}
+
+// Forget tells the singleflight to forget about a key.  Future calls
+// to Do for this key will call the function rather than waiting for
+// an earlier call to complete.
+func (g *Group) Forget(key string) {
+	g.mu.Lock()
+	delete(g.m, key)
+	g.mu.Unlock()
+}


### PR DESCRIPTION
Updating entries in the cache has been made async. This ensures that
1) requests are not blocked waiting for re-validation of tokens and
   instances
2) we dont get into situations where we flood grafana.com with
   validation requests

Instead of updating the cached entries when they are past their TTL,
We run a background tasks that scans over the cached items looking
for expired entries and re-validating them.

On reads of the cache, we update a lastRead timer.  If this timer
falls behind the last validation then we know that the cached item
is no longer being read, so we purge it from the cache.

To handle the background tasks, the AuthPlugin interface has been updated
to ensure plugins have a "Stop()" method.

Finally the auth-valid-ttl and auth-invalid-ttl cmdline args have been
replaced with a single 'auth-cache-ttl' arg, which defaults to 1hour.