### PR TITLE
Disable persistent connections

### DIFF
--- a/publish/cortex/proxy.go
+++ b/publish/cortex/proxy.go
@@ -6,6 +6,7 @@ import (
 	"github.com/raintank/tsdb-gw/api/models"
 )
 
+// Write adds the required headers and forwards the write request.
 func Write(c *models.Context) {
 	c.Req.Request.Header.Set("X-Scope-OrgID", strconv.Itoa(c.User.ID))
 	writeProxy.ServeHTTP(c.Resp, c.Req.Request)

--- a/publish/cortex/publish.go
+++ b/publish/cortex/publish.go
@@ -93,6 +93,7 @@ func Init() {
 			MaxIdleConns:          10000,
 			MaxIdleConnsPerHost:   1000, // see https://github.com/golang/go/issues/13801
 			IdleConnTimeout:       90 * time.Second,
+			DisableKeepAlives:     true,
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},

--- a/publish/cortex/publish.go
+++ b/publish/cortex/publish.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/prometheus/prompb"
 	schema "github.com/raintank/schema"
+	"github.com/raintank/tsdb-gw/publish"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context/ctxhttp"
 )
@@ -109,7 +110,8 @@ type cortexPublisher struct {
 	timeout time.Duration
 }
 
-func NewCortexPublisher() *cortexPublisher {
+// NewCortexPublisher creates a new cortex publisher.
+func NewCortexPublisher() publish.Publisher {
 	return &cortexPublisher{
 		url: cortexURL,
 		client: &http.Client{


### PR DESCRIPTION
This fixes the bad load-balancing. Adds some latency but literally better than before.

See: https://github.com/raintank/tsdb-gw/pull/126#issuecomment-434011531