### PR TITLE
Add support for websockets

### DIFF
--- a/api/middleware.go
+++ b/api/middleware.go
@@ -1,10 +1,12 @@
 package api
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"net/http"
 	"path"
 	"strconv"
@@ -49,6 +51,14 @@ func (rw *TracingResponseWriter) Write(b []byte) (int, error) {
 		copy(rw.errBody, b)
 	}
 	return rw.ResponseWriter.Write(b)
+}
+
+func (rw *TracingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("the ResponseWriter doesn't support the Hijacker interface")
+	}
+	return hijacker.Hijack()
 }
 
 func GetContextHandler() macaron.Handler {


### PR DESCRIPTION
To support websockets with reverse proxy, response writer needs to satisfy `http.Hijacker` interface.
Added this method to `TracingResponseWriter` which in turn calls underlying Hijack method implemented by `macaron.ResponseWriter`

This is needed to support live tailing of logs from loki