### PR TITLE
Support publishing to multiple Kafka topics with restriction by org id

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -28,9 +28,12 @@
   revision = "f61b7225d304620f6f2c5cbb21435d0957115429"
 
 [[projects]]
-  digest = "1:a074ae0f4788ea4c4c7045ab37f21943920bc20cf6ff8afcb2d971154cfa87ab"
+  digest = "1:e22217b1fd7a20d7cc1ec7e49b83e63be449ad95bdc7a8dfca3d996a9014bba3"
   name = "github.com/Shopify/sarama"
-  packages = ["."]
+  packages = [
+    ".",
+    "mocks",
+  ]
   pruneopts = "NUT"
   revision = "ec843464b50d4c8b56403ec9d589cf41ea30e722"
   version = "v1.19.0"
@@ -830,6 +833,7 @@
   input-imports = [
     "cloud.google.com/go/bigtable",
     "github.com/Shopify/sarama",
+    "github.com/Shopify/sarama/mocks",
     "github.com/go-macaron/binding",
     "github.com/gogo/protobuf/proto",
     "github.com/golang/snappy",

--- a/auth/gcom/auth.go
+++ b/auth/gcom/auth.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/raintank/tsdb-gw/util"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/sync/singleflight"
 )
@@ -34,31 +35,9 @@ func init() {
 	flag.BoolVar(&validationDryRun, "auth-validation-dry-run", true, "if true, invalid instance type and cluster would just cause logging of the bad requests but not an actual failure of the request.")
 }
 
-type int64SliceFlag []int64
-
-func (i *int64SliceFlag) Set(value string) error {
-	for _, split := range strings.Split(value, ",") {
-		split = strings.TrimSpace(split)
-		if split == "" {
-			continue
-		}
-		parsed, err := strconv.Atoi(split)
-		if err != nil {
-			return err
-		}
-		*i = append(*i, int64(parsed))
-	}
-	return nil
-}
-
-func (i *int64SliceFlag) String() string {
-	// This is just a 1-liner to convert print a slice as a command separated list.
-	return strings.Trim(strings.Replace(fmt.Sprint(*i), " ", ", ", -1), "[]")
-}
-
 var (
 	authEndpoint      = "https://grafana.com"
-	validOrgIds       = int64SliceFlag{}
+	validOrgIds       = util.Int64SliceFlag{}
 	validInstanceType string
 	validClusterID    int
 	validationDryRun  bool

--- a/auth/gcom/auth_test.go
+++ b/auth/gcom/auth_test.go
@@ -10,31 +10,32 @@ import (
 	"time"
 
 	"github.com/jarcoal/httpmock"
+	"github.com/raintank/tsdb-gw/util"
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestFlags(t *testing.T) {
 	Convey("When setting auth-valid-org-id to empty string", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", "")
 		c.So(err, ShouldBeNil)
 		c.So(validOrgIds, ShouldHaveLength, 0)
 	})
 	Convey("When setting auth-valid-org-id has no values", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", ", ")
 		c.So(err, ShouldBeNil)
 		c.So(validOrgIds, ShouldHaveLength, 0)
 	})
 
 	Convey("When setting auth-valid-org-id to invalid value", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", "foo")
 		c.So(err, ShouldHaveSameTypeAs, &strconv.NumError{})
 	})
 
 	Convey("When setting auth-valid-org-id to single org", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", "10")
 		c.So(err, ShouldBeNil)
 		c.So(validOrgIds, ShouldHaveLength, 1)
@@ -42,7 +43,7 @@ func TestFlags(t *testing.T) {
 	})
 
 	Convey("When setting auth-valid-org-id to many orgs", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", "10,1,17")
 		c.So(err, ShouldBeNil)
 		c.So(validOrgIds, ShouldHaveLength, 3)
@@ -52,7 +53,7 @@ func TestFlags(t *testing.T) {
 	})
 
 	Convey("When auth-valid-org-id setting has spaces", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", " 10 , 1, 17")
 		c.So(err, ShouldBeNil)
 		c.So(validOrgIds, ShouldHaveLength, 3)
@@ -62,7 +63,7 @@ func TestFlags(t *testing.T) {
 	})
 
 	Convey("When auth-valid-org-id setting has repeated commas", t, func(c C) {
-		validOrgIds = int64SliceFlag{}
+		validOrgIds = util.Int64SliceFlag{}
 		err := flag.Set("auth-valid-org-id", ",,,10")
 		c.So(err, ShouldBeNil)
 		c.So(validOrgIds, ShouldHaveLength, 1)
@@ -72,7 +73,7 @@ func TestFlags(t *testing.T) {
 func TestAuth(t *testing.T) {
 	mockTransport := httpmock.NewMockTransport()
 	client.Transport = mockTransport
-	validOrgIds = int64SliceFlag{}
+	validOrgIds = util.Int64SliceFlag{}
 	testUser := SignedInUser{
 		Id:        3,
 		OrgName:   "awoods Test",
@@ -136,7 +137,7 @@ func TestAuth(t *testing.T) {
 
 		originalValidOrgIds := validOrgIds
 		defer func() { validOrgIds = originalValidOrgIds }()
-		validOrgIds = int64SliceFlag{1}
+		validOrgIds = util.Int64SliceFlag{1}
 
 		user, err := Auth("key", "foo")
 		c.So(user, ShouldBeNil)
@@ -153,7 +154,7 @@ func TestAuth(t *testing.T) {
 		originalValidOrgIds := validOrgIds
 		defer func() { validOrgIds = originalValidOrgIds }()
 
-		validOrgIds = int64SliceFlag{3, 4, 5}
+		validOrgIds = util.Int64SliceFlag{3, 4, 5}
 		user, err := Auth("key", "foo")
 		c.So(user, ShouldBeNil)
 		c.So(err, ShouldEqual, ErrInvalidOrgId)
@@ -169,7 +170,7 @@ func TestAuth(t *testing.T) {
 		originalValidOrgIds := validOrgIds
 		defer func() { validOrgIds = originalValidOrgIds }()
 
-		validOrgIds = int64SliceFlag{1, 2, 3, 4}
+		validOrgIds = util.Int64SliceFlag{1, 2, 3, 4}
 		user, err := Auth("key", "foo")
 		c.So(err, ShouldBeNil)
 		c.So(user.Role, ShouldEqual, testUser.Role)

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -97,7 +97,14 @@ func getCompression(codec string) sarama.CompressionCodec {
 func parseTopicSettings(partitionSchemesStr, topicsStr string, onlyOrgIds []int64) ([]topicSettings, error) {
 	var topics []topicSettings
 	partitionSchemes := strings.Split(partitionSchemesStr, ",")
-	for i, topicName := range strings.Split(topicsStr, ",") {
+	topicsStrList := strings.Split(topicsStr, ",")
+	if len(partitionSchemes) > 1 && len(partitionSchemes) != len(topicsStrList) {
+		return nil, errors.New("More partition schemes (metrics-partition-scheme) than topics (metrics-topic)")
+	}
+	if len(onlyOrgIds) > 1 && len(onlyOrgIds) != len(topicsStrList) {
+		return nil, errors.New("More org ids (only-org-id) than topics (metrics-topic)")
+	}
+	for i, topicName := range topicsStrList {
 		topicName = strings.TrimSpace(topicName)
 		var partitioner *p.Kafka
 		if len(partitionSchemes) == 1 && i > 0 {

--- a/publish/kafka/publish_test.go
+++ b/publish/kafka/publish_test.go
@@ -123,6 +123,56 @@ func Test_parseTopicSettings(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:                "two_topics_mismatched_scheme_count",
+			partitionSchemesStr: "bySeries,byOrg,byOrg",
+			topicsStr:           "testTopic1,testTopic2",
+			onlyOrgIdsStr:       "",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					onlyOrgId: 0,
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					onlyOrgId: 0,
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:                "two_topics_mismatched_only_org_id_count",
+			partitionSchemesStr: "bySeries,byOrg",
+			topicsStr:           "testTopic1,testTopic2",
+			onlyOrgIdsStr:       "1,10,42",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					onlyOrgId: 1,
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					onlyOrgId: 10,
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name:                "two_topics_with_spaces",
 			partitionSchemesStr: "bySeries  ,byOrg",
 			topicsStr:           "testTopic1,  testTopic2",
@@ -198,7 +248,7 @@ func Test_parseTopicSettings(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:                "one_topic_more_schemes_ignored",
+			name:                "one_topic_mismatched_more_schemes",
 			partitionSchemesStr: "bySeries,byOrg",
 			topicsStr:           "testTopic",
 			onlyOrgIdsStr:       "",
@@ -212,7 +262,7 @@ func Test_parseTopicSettings(t *testing.T) {
 					onlyOrgId: 0,
 				},
 			},
-			wantErr: false,
+			wantErr: true,
 		},
 	}
 	for _, test := range tests {

--- a/publish/kafka/publish_test.go
+++ b/publish/kafka/publish_test.go
@@ -1,0 +1,327 @@
+package kafka
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/Shopify/sarama"
+	"github.com/Shopify/sarama/mocks"
+	"github.com/grafana/metrictank/cluster/partitioner"
+	"github.com/raintank/schema"
+	"github.com/raintank/tsdb-gw/publish/kafka/keycache"
+)
+
+func Test_parseTopicSettings(t *testing.T) {
+	tests := []struct {
+		name                string
+		partitionSchemesStr string
+		topicsStr           string
+		expected            []topicSettings
+		wantErr             bool
+	}{
+		{
+			name:                "no_topic",
+			partitionSchemesStr: "",
+			topicsStr:           "",
+			expected:            []topicSettings{},
+			wantErr:             true,
+		},
+		{
+			name:                "single_topic",
+			partitionSchemesStr: "bySeries",
+			topicsStr:           "testTopic",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:                "two_topics_same_scheme",
+			partitionSchemesStr: "bySeries,bySeries",
+			topicsStr:           "testTopic1,testTopic2",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:                "two_topics_different_scheme",
+			partitionSchemesStr: "bySeries,byOrg",
+			topicsStr:           "testTopic1,testTopic2",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:                "two_topics_with_spaces",
+			partitionSchemesStr: "bySeries  ,byOrg",
+			topicsStr:           "testTopic1,  testTopic2",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:                "two_topics_shared_scheme",
+			partitionSchemesStr: "bySeries",
+			topicsStr:           "testTopic1,testTopic2",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:                "one_topic_more_schemes_ignored",
+			partitionSchemesStr: "bySeries,byOrg",
+			topicsStr:           "testTopic",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := parseTopicSettings(test.partitionSchemesStr, test.topicsStr)
+			if (err != nil) != test.wantErr {
+				t.Errorf("parseTopicSettings() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			for i, topicSetting := range got {
+				if topicSetting.name != test.expected[i].name {
+					t.Errorf("parseTopicSettings(): incorrect topic name %s, expects %s", topicSetting.name, test.expected[i].name)
+				}
+				if topicSetting.partitioner.PartitionBy != test.expected[i].partitioner.PartitionBy {
+					t.Errorf("parseTopicSettings(): incorrect partition scheme %s, expects %s", topicSetting.partitioner.PartitionBy, test.expected[i].partitioner.PartitionBy)
+				}
+				if topicSetting.partitioner.Partitioner == nil {
+					t.Errorf("parseTopicSettings(): nil partitioner")
+				}
+			}
+		})
+	}
+}
+
+func Test_Publish(t *testing.T) {
+	dataSinglePoint := []*schema.MetricData{
+		{
+			Name:     "a.b.c",
+			OrgId:    1,
+			Interval: 10,
+		},
+	}
+	for _, metric := range dataSinglePoint {
+		metric.SetId()
+	}
+	dataManyPoints := []*schema.MetricData{
+		{
+			Name:     "a.b.c",
+			OrgId:    1,
+			Interval: 10,
+		},
+		{
+			Name:     "a.b.c.d",
+			OrgId:    1,
+			Interval: 10,
+		},
+		{
+			Name:     "a.b.c2",
+			OrgId:    1,
+			Interval: 10,
+		},
+	}
+	for _, metric := range dataManyPoints {
+		metric.SetId()
+	}
+
+	tests := []struct {
+		name    string
+		topics  []topicSettings
+		data    []*schema.MetricData
+		wantErr bool
+	}{
+		{
+			name:    "no_topic",
+			topics:  []topicSettings{},
+			data:    dataManyPoints,
+			wantErr: false,
+		},
+		{
+			name: "single_topic_single_point",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			data:    dataSinglePoint,
+			wantErr: false,
+		},
+		{
+			name: "single_topic_many_points",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			data:    dataManyPoints,
+			wantErr: false,
+		},
+		{
+			name: "two_topics_single_point",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			data:    dataSinglePoint,
+			wantErr: false,
+		},
+		{
+			name: "two_topics_many_points",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+			},
+			data:    dataManyPoints,
+			wantErr: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			publisher := mtPublisher{
+				autoInterval: false,
+				topics:       test.topics,
+			}
+			mockProducer := mocks.NewSyncProducer(t, nil)
+			producer = mockProducer
+			keyCache = keycache.NewKeyCache(v2ClearInterval)
+
+			// check that each MetricData is sent once per topic when calling Publish
+			for range test.topics {
+				for i, _ := range test.data {
+					expectedMd := test.data[i]
+					mockProducer.ExpectSendMessageWithCheckerFunctionAndSucceed(func(sentData []byte) error {
+						expectedData := make([]byte, 0)
+						expectedData, err := expectedMd.MarshalMsg(expectedData)
+						if err != nil {
+							return err
+						}
+						if bytes.Compare(sentData, expectedData) != 0 {
+							sentMd := schema.MetricData{}
+							_, err := sentMd.UnmarshalMsg(sentData)
+							if err != nil {
+								return err
+							}
+							return errors.New(fmt.Sprintf("Message sent different from expected: %v != %v", sentMd, expectedMd))
+						}
+						return nil
+					})
+				}
+			}
+			err := publisher.Publish(test.data)
+			if (err != nil) != test.wantErr {
+				t.Errorf("Publish() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+		})
+	}
+
+}

--- a/util/flags.go
+++ b/util/flags.go
@@ -37,6 +37,6 @@ func (i *Int64SliceFlag) Set(value string) error {
 }
 
 func (i *Int64SliceFlag) String() string {
-	// This is just a 1-liner to convert print a slice as a command separated list.
+	// This is just a 1-liner to print a slice as a comma separated list.
 	return strings.Trim(strings.Replace(fmt.Sprint(*i), " ", ", ", -1), "[]")
 }

--- a/util/flags.go
+++ b/util/flags.go
@@ -2,6 +2,9 @@ package util
 
 import (
 	"flag"
+	"fmt"
+	"strconv"
+	"strings"
 )
 
 // Registerer is a thing that can RegisterFlags
@@ -14,4 +17,26 @@ func RegisterFlags(rs ...Registerer) {
 	for _, r := range rs {
 		r.RegisterFlags(flag.CommandLine)
 	}
+}
+
+type Int64SliceFlag []int64
+
+func (i *Int64SliceFlag) Set(value string) error {
+	for _, split := range strings.Split(value, ",") {
+		split = strings.TrimSpace(split)
+		if split == "" {
+			continue
+		}
+		parsed, err := strconv.Atoi(split)
+		if err != nil {
+			return err
+		}
+		*i = append(*i, int64(parsed))
+	}
+	return nil
+}
+
+func (i *Int64SliceFlag) String() string {
+	// This is just a 1-liner to convert print a slice as a command separated list.
+	return strings.Trim(strings.Replace(fmt.Sprint(*i), " ", ", ", -1), "[]")
 }

--- a/util/flags_test.go
+++ b/util/flags_test.go
@@ -1,0 +1,64 @@
+package util
+
+import (
+	"strconv"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestInt64SliceFlag(t *testing.T) {
+	Convey("When setting Int64SliceFlag to empty string", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set("")
+		c.So(err, ShouldBeNil)
+		c.So(intSliceFlag, ShouldHaveLength, 0)
+	})
+	Convey("When setting Int64SliceFlag has no values", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set(", ")
+		c.So(err, ShouldBeNil)
+		c.So(intSliceFlag, ShouldHaveLength, 0)
+	})
+
+	Convey("When setting Int64SliceFlag to invalid value", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set("foo")
+		c.So(err, ShouldHaveSameTypeAs, &strconv.NumError{})
+	})
+
+	Convey("When setting Int64SliceFlag to single org", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set("10")
+		c.So(err, ShouldBeNil)
+		c.So(intSliceFlag, ShouldHaveLength, 1)
+		c.So(intSliceFlag[0], ShouldEqual, 10)
+	})
+
+	Convey("When setting Int64SliceFlag to many orgs", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set("10,1,17")
+		c.So(err, ShouldBeNil)
+		c.So(intSliceFlag, ShouldHaveLength, 3)
+		c.So(intSliceFlag[0], ShouldEqual, 10)
+		c.So(intSliceFlag[1], ShouldEqual, 1)
+		c.So(intSliceFlag[2], ShouldEqual, 17)
+	})
+
+	Convey("When Int64SliceFlag setting has spaces", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set(" 10 , 1, 17")
+		c.So(err, ShouldBeNil)
+		c.So(intSliceFlag, ShouldHaveLength, 3)
+		c.So(intSliceFlag[0], ShouldEqual, 10)
+		c.So(intSliceFlag[1], ShouldEqual, 1)
+		c.So(intSliceFlag[2], ShouldEqual, 17)
+	})
+
+	Convey("When Int64SliceFlag setting has repeated commas", t, func(c C) {
+		intSliceFlag := Int64SliceFlag{}
+		err := intSliceFlag.Set(",,,10")
+		c.So(err, ShouldBeNil)
+		c.So(intSliceFlag, ShouldHaveLength, 1)
+	})
+}

--- a/vendor/github.com/Shopify/sarama/mocks/async_producer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/async_producer.go
@@ -1,0 +1,173 @@
+package mocks
+
+import (
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+// AsyncProducer implements sarama's Producer interface for testing purposes.
+// Before you can send messages to it's Input channel, you have to set expectations
+// so it knows how to handle the input; it returns an error if the number of messages
+// received is bigger then the number of expectations set. You can also set a
+// function in each expectation so that the message value is checked by this function
+// and an error is returned if the match fails.
+type AsyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	closed       chan struct{}
+	input        chan *sarama.ProducerMessage
+	successes    chan *sarama.ProducerMessage
+	errors       chan *sarama.ProducerError
+	lastOffset   int64
+}
+
+// NewAsyncProducer instantiates a new Producer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is used to determine whether it
+// should ack successes on the Successes channel.
+func NewAsyncProducer(t ErrorReporter, config *sarama.Config) *AsyncProducer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+	mp := &AsyncProducer{
+		t:            t,
+		closed:       make(chan struct{}, 0),
+		expectations: make([]*producerExpectation, 0),
+		input:        make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		successes:    make(chan *sarama.ProducerMessage, config.ChannelBufferSize),
+		errors:       make(chan *sarama.ProducerError, config.ChannelBufferSize),
+	}
+
+	go func() {
+		defer func() {
+			close(mp.successes)
+			close(mp.errors)
+			close(mp.closed)
+		}()
+
+		for msg := range mp.input {
+			mp.l.Lock()
+			if mp.expectations == nil || len(mp.expectations) == 0 {
+				mp.expectations = nil
+				mp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+			} else {
+				expectation := mp.expectations[0]
+				mp.expectations = mp.expectations[1:]
+				if expectation.CheckFunction != nil {
+					if val, err := msg.Value.Encode(); err != nil {
+						mp.t.Errorf("Input message encoding failed: %s", err.Error())
+						mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+					} else {
+						err = expectation.CheckFunction(val)
+						if err != nil {
+							mp.t.Errorf("Check function returned an error: %s", err.Error())
+							mp.errors <- &sarama.ProducerError{Err: err, Msg: msg}
+						}
+					}
+				}
+				if expectation.Result == errProduceSuccess {
+					mp.lastOffset++
+					if config.Producer.Return.Successes {
+						msg.Offset = mp.lastOffset
+						mp.successes <- msg
+					}
+				} else {
+					if config.Producer.Return.Errors {
+						mp.errors <- &sarama.ProducerError{Err: expectation.Result, Msg: msg}
+					}
+				}
+			}
+			mp.l.Unlock()
+		}
+
+		mp.l.Lock()
+		if len(mp.expectations) > 0 {
+			mp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(mp.expectations))
+		}
+		mp.l.Unlock()
+	}()
+
+	return mp
+}
+
+////////////////////////////////////////////////
+// Implement Producer interface
+////////////////////////////////////////////////
+
+// AsyncClose corresponds with the AsyncClose method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) AsyncClose() {
+	close(mp.input)
+}
+
+// Close corresponds with the Close method of sarama's Producer implementation.
+// By closing a mock producer, you also tell it that no more input will be provided, so it will
+// write an error to the test state if there's any remaining expectations.
+func (mp *AsyncProducer) Close() error {
+	mp.AsyncClose()
+	<-mp.closed
+	return nil
+}
+
+// Input corresponds with the Input method of sarama's Producer implementation.
+// You have to set expectations on the mock producer before writing messages to the Input
+// channel, so it knows how to handle them. If there is no more remaining expectations and
+// a messages is written to the Input channel, the mock producer will write an error to the test
+// state object.
+func (mp *AsyncProducer) Input() chan<- *sarama.ProducerMessage {
+	return mp.input
+}
+
+// Successes corresponds with the Successes method of sarama's Producer implementation.
+func (mp *AsyncProducer) Successes() <-chan *sarama.ProducerMessage {
+	return mp.successes
+}
+
+// Errors corresponds with the Errors method of sarama's Producer implementation.
+func (mp *AsyncProducer) Errors() <-chan *sarama.ProducerError {
+	return mp.errors
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectInputWithCheckerFunctionAndSucceed sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will call the given function to check
+// the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it produced successfully, i.e. it will make
+// it available on the Successes channel if the Producer.Return.Successes setting is set to true.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndSucceed(cf ValueChecker) {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+}
+
+// ExpectInputWithCheckerFunctionAndFail sets an expectation on the mock producer that a message
+// will be provided on the input channel. The mock producer will first call the given function to
+// check the message value. If an error is returned it will be made available on the Errors channel
+// otherwise the mock will handle the message as if it failed to produce successfully. This means
+// it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputWithCheckerFunctionAndFail(cf ValueChecker, err error) {
+	mp.l.Lock()
+	defer mp.l.Unlock()
+	mp.expectations = append(mp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+}
+
+// ExpectInputAndSucceed sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it is produced successfully,
+// i.e. it will make it available on the Successes channel if the Producer.Return.Successes setting
+// is set to true.
+func (mp *AsyncProducer) ExpectInputAndSucceed() {
+	mp.ExpectInputWithCheckerFunctionAndSucceed(nil)
+}
+
+// ExpectInputAndFail sets an expectation on the mock producer that a message will be provided
+// on the input channel. The mock producer will handle the message as if it failed to produce
+// successfully. This means it will make a ProducerError available on the Errors channel.
+func (mp *AsyncProducer) ExpectInputAndFail(err error) {
+	mp.ExpectInputWithCheckerFunctionAndFail(nil, err)
+}

--- a/vendor/github.com/Shopify/sarama/mocks/consumer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/consumer.go
@@ -1,0 +1,315 @@
+package mocks
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/Shopify/sarama"
+)
+
+// Consumer implements sarama's Consumer interface for testing purposes.
+// Before you can start consuming from this consumer, you have to register
+// topic/partitions using ExpectConsumePartition, and set expectations on them.
+type Consumer struct {
+	l                  sync.Mutex
+	t                  ErrorReporter
+	config             *sarama.Config
+	partitionConsumers map[string]map[int32]*PartitionConsumer
+	metadata           map[string][]int32
+}
+
+// NewConsumer returns a new mock Consumer instance. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument can be set to nil.
+func NewConsumer(t ErrorReporter, config *sarama.Config) *Consumer {
+	if config == nil {
+		config = sarama.NewConfig()
+	}
+
+	c := &Consumer{
+		t:                  t,
+		config:             config,
+		partitionConsumers: make(map[string]map[int32]*PartitionConsumer),
+	}
+	return c
+}
+
+///////////////////////////////////////////////////
+// Consumer interface implementation
+///////////////////////////////////////////////////
+
+// ConsumePartition implements the ConsumePartition method from the sarama.Consumer interface.
+// Before you can start consuming a partition, you have to set expectations on it using
+// ExpectConsumePartition. You can only consume a partition once per consumer.
+func (c *Consumer) ConsumePartition(topic string, partition int32, offset int64) (sarama.PartitionConsumer, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil || c.partitionConsumers[topic][partition] == nil {
+		c.t.Errorf("No expectations set for %s/%d", topic, partition)
+		return nil, errOutOfExpectations
+	}
+
+	pc := c.partitionConsumers[topic][partition]
+	if pc.consumed {
+		return nil, sarama.ConfigurationError("The topic/partition is already being consumed")
+	}
+
+	if pc.offset != AnyOffset && pc.offset != offset {
+		c.t.Errorf("Unexpected offset when calling ConsumePartition for %s/%d. Expected %d, got %d.", topic, partition, pc.offset, offset)
+	}
+
+	pc.consumed = true
+	return pc, nil
+}
+
+// Topics returns a list of topics, as registered with SetMetadata
+func (c *Consumer) Topics() ([]string, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Topics. Initialize the mock's topic metadata with SetMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+
+	var result []string
+	for topic := range c.metadata {
+		result = append(result, topic)
+	}
+	return result, nil
+}
+
+// Partitions returns the list of parititons for the given topic, as registered with SetMetadata
+func (c *Consumer) Partitions(topic string) ([]int32, error) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.metadata == nil {
+		c.t.Errorf("Unexpected call to Partitions. Initialize the mock's topic metadata with SetMetadata.")
+		return nil, sarama.ErrOutOfBrokers
+	}
+	if c.metadata[topic] == nil {
+		return nil, sarama.ErrUnknownTopicOrPartition
+	}
+
+	return c.metadata[topic], nil
+}
+
+func (c *Consumer) HighWaterMarks() map[string]map[int32]int64 {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	hwms := make(map[string]map[int32]int64, len(c.partitionConsumers))
+	for topic, partitionConsumers := range c.partitionConsumers {
+		hwm := make(map[int32]int64, len(partitionConsumers))
+		for partition, pc := range partitionConsumers {
+			hwm[partition] = pc.HighWaterMarkOffset()
+		}
+		hwms[topic] = hwm
+	}
+
+	return hwms
+}
+
+// Close implements the Close method from the sarama.Consumer interface. It will close
+// all registered PartitionConsumer instances.
+func (c *Consumer) Close() error {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	for _, partitions := range c.partitionConsumers {
+		for _, partitionConsumer := range partitions {
+			_ = partitionConsumer.Close()
+		}
+	}
+
+	return nil
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// SetTopicMetadata sets the clusters topic/partition metadata,
+// which will be returned by Topics() and Partitions().
+func (c *Consumer) SetTopicMetadata(metadata map[string][]int32) {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	c.metadata = metadata
+}
+
+// ExpectConsumePartition will register a topic/partition, so you can set expectations on it.
+// The registered PartitionConsumer will be returned, so you can set expectations
+// on it using method chaining. Once a topic/partition is registered, you are
+// expected to start consuming it using ConsumePartition. If that doesn't happen,
+// an error will be written to the error reporter once the mock consumer is closed. It will
+// also expect that the
+func (c *Consumer) ExpectConsumePartition(topic string, partition int32, offset int64) *PartitionConsumer {
+	c.l.Lock()
+	defer c.l.Unlock()
+
+	if c.partitionConsumers[topic] == nil {
+		c.partitionConsumers[topic] = make(map[int32]*PartitionConsumer)
+	}
+
+	if c.partitionConsumers[topic][partition] == nil {
+		c.partitionConsumers[topic][partition] = &PartitionConsumer{
+			t:         c.t,
+			topic:     topic,
+			partition: partition,
+			offset:    offset,
+			messages:  make(chan *sarama.ConsumerMessage, c.config.ChannelBufferSize),
+			errors:    make(chan *sarama.ConsumerError, c.config.ChannelBufferSize),
+		}
+	}
+
+	return c.partitionConsumers[topic][partition]
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer mock type
+///////////////////////////////////////////////////
+
+// PartitionConsumer implements sarama's PartitionConsumer interface for testing purposes.
+// It is returned by the mock Consumers ConsumePartitionMethod, but only if it is
+// registered first using the Consumer's ExpectConsumePartition method. Before consuming the
+// Errors and Messages channel, you should specify what values will be provided on these
+// channels using YieldMessage and YieldError.
+type PartitionConsumer struct {
+	highWaterMarkOffset     int64 // must be at the top of the struct because https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	l                       sync.Mutex
+	t                       ErrorReporter
+	topic                   string
+	partition               int32
+	offset                  int64
+	messages                chan *sarama.ConsumerMessage
+	errors                  chan *sarama.ConsumerError
+	singleClose             sync.Once
+	consumed                bool
+	errorsShouldBeDrained   bool
+	messagesShouldBeDrained bool
+}
+
+///////////////////////////////////////////////////
+// PartitionConsumer interface implementation
+///////////////////////////////////////////////////
+
+// AsyncClose implements the AsyncClose method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) AsyncClose() {
+	pc.singleClose.Do(func() {
+		close(pc.messages)
+		close(pc.errors)
+	})
+}
+
+// Close implements the Close method from the sarama.PartitionConsumer interface. It will
+// verify whether the partition consumer was actually started.
+func (pc *PartitionConsumer) Close() error {
+	if !pc.consumed {
+		pc.t.Errorf("Expectations set on %s/%d, but no partition consumer was started.", pc.topic, pc.partition)
+		return errPartitionConsumerNotStarted
+	}
+
+	if pc.errorsShouldBeDrained && len(pc.errors) > 0 {
+		pc.t.Errorf("Expected the errors channel for %s/%d to be drained on close, but found %d errors.", pc.topic, pc.partition, len(pc.errors))
+	}
+
+	if pc.messagesShouldBeDrained && len(pc.messages) > 0 {
+		pc.t.Errorf("Expected the messages channel for %s/%d to be drained on close, but found %d messages.", pc.topic, pc.partition, len(pc.messages))
+	}
+
+	pc.AsyncClose()
+
+	var (
+		closeErr error
+		wg       sync.WaitGroup
+	)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		var errs = make(sarama.ConsumerErrors, 0)
+		for err := range pc.errors {
+			errs = append(errs, err)
+		}
+
+		if len(errs) > 0 {
+			closeErr = errs
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range pc.messages {
+			// drain
+		}
+	}()
+
+	wg.Wait()
+	return closeErr
+}
+
+// Errors implements the Errors method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Errors() <-chan *sarama.ConsumerError {
+	return pc.errors
+}
+
+// Messages implements the Messages method from the sarama.PartitionConsumer interface.
+func (pc *PartitionConsumer) Messages() <-chan *sarama.ConsumerMessage {
+	return pc.messages
+}
+
+func (pc *PartitionConsumer) HighWaterMarkOffset() int64 {
+	return atomic.LoadInt64(&pc.highWaterMarkOffset) + 1
+}
+
+///////////////////////////////////////////////////
+// Expectation API
+///////////////////////////////////////////////////
+
+// YieldMessage will yield a messages Messages channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this
+// message was consumed from the Messages channel, because there are legitimate
+// reasons forthis not to happen. ou can call ExpectMessagesDrainedOnClose so it will
+// verify that the channel is empty on close.
+func (pc *PartitionConsumer) YieldMessage(msg *sarama.ConsumerMessage) {
+	pc.l.Lock()
+	defer pc.l.Unlock()
+
+	msg.Topic = pc.topic
+	msg.Partition = pc.partition
+	msg.Offset = atomic.AddInt64(&pc.highWaterMarkOffset, 1)
+
+	pc.messages <- msg
+}
+
+// YieldError will yield an error on the Errors channel of this partition consumer
+// when it is consumed. By default, the mock consumer will not verify whether this error was
+// consumed from the Errors channel, because there are legitimate reasons for this
+// not to happen. You can call ExpectErrorsDrainedOnClose so it will verify that
+// the channel is empty on close.
+func (pc *PartitionConsumer) YieldError(err error) {
+	pc.errors <- &sarama.ConsumerError{
+		Topic:     pc.topic,
+		Partition: pc.partition,
+		Err:       err,
+	}
+}
+
+// ExpectMessagesDrainedOnClose sets an expectation on the partition consumer
+// that the messages channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectMessagesDrainedOnClose() {
+	pc.messagesShouldBeDrained = true
+}
+
+// ExpectErrorsDrainedOnClose sets an expectation on the partition consumer
+// that the errors channel will be fully drained when Close is called. If this
+// expectation is not met, an error is reported to the error reporter.
+func (pc *PartitionConsumer) ExpectErrorsDrainedOnClose() {
+	pc.errorsShouldBeDrained = true
+}

--- a/vendor/github.com/Shopify/sarama/mocks/mocks.go
+++ b/vendor/github.com/Shopify/sarama/mocks/mocks.go
@@ -1,0 +1,48 @@
+/*
+Package mocks provides mocks that can be used for testing applications
+that use Sarama. The mock types provided by this package implement the
+interfaces Sarama exports, so you can use them for dependency injection
+in your tests.
+
+All mock instances require you to set expectations on them before you
+can use them. It will determine how the mock will behave. If an
+expectation is not met, it will make your test fail.
+
+NOTE: this package currently does not fall under the API stability
+guarantee of Sarama as it is still considered experimental.
+*/
+package mocks
+
+import (
+	"errors"
+
+	"github.com/Shopify/sarama"
+)
+
+// ErrorReporter is a simple interface that includes the testing.T methods we use to report
+// expectation violations when using the mock objects.
+type ErrorReporter interface {
+	Errorf(string, ...interface{})
+}
+
+// ValueChecker is a function type to be set in each expectation of the producer mocks
+// to check the value passed.
+type ValueChecker func(val []byte) error
+
+var (
+	errProduceSuccess              error = nil
+	errOutOfExpectations                 = errors.New("No more expectations set on mock")
+	errPartitionConsumerNotStarted       = errors.New("The partition consumer was never started")
+)
+
+const AnyOffset int64 = -1000
+
+type producerExpectation struct {
+	Result        error
+	CheckFunction ValueChecker
+}
+
+type consumerExpectation struct {
+	Err error
+	Msg *sarama.ConsumerMessage
+}

--- a/vendor/github.com/Shopify/sarama/mocks/sync_producer.go
+++ b/vendor/github.com/Shopify/sarama/mocks/sync_producer.go
@@ -1,0 +1,157 @@
+package mocks
+
+import (
+	"sync"
+
+	"github.com/Shopify/sarama"
+)
+
+// SyncProducer implements sarama's SyncProducer interface for testing purposes.
+// Before you can use it, you have to set expectations on the mock SyncProducer
+// to tell it how to handle calls to SendMessage, so you can easily test success
+// and failure scenarios.
+type SyncProducer struct {
+	l            sync.Mutex
+	t            ErrorReporter
+	expectations []*producerExpectation
+	lastOffset   int64
+}
+
+// NewSyncProducer instantiates a new SyncProducer mock. The t argument should
+// be the *testing.T instance of your test method. An error will be written to it if
+// an expectation is violated. The config argument is currently unused, but is
+// maintained to be compatible with the async Producer.
+func NewSyncProducer(t ErrorReporter, config *sarama.Config) *SyncProducer {
+	return &SyncProducer{
+		t:            t,
+		expectations: make([]*producerExpectation, 0),
+	}
+}
+
+////////////////////////////////////////////////
+// Implement SyncProducer interface
+////////////////////////////////////////////////
+
+// SendMessage corresponds with the SendMessage method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessage, so it knows
+// how to handle them. You can set a function in each expectation so that the message value
+// checked by this function and an error is returned if the match fails.
+// If there is no more remaining expectation when SendMessage is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessage(msg *sarama.ProducerMessage) (partition int32, offset int64, err error) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		expectation := sp.expectations[0]
+		sp.expectations = sp.expectations[1:]
+		if expectation.CheckFunction != nil {
+			val, err := msg.Value.Encode()
+			if err != nil {
+				sp.t.Errorf("Input message encoding failed: %s", err.Error())
+				return -1, -1, err
+			}
+
+			errCheck := expectation.CheckFunction(val)
+			if errCheck != nil {
+				sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+				return -1, -1, errCheck
+			}
+		}
+		if expectation.Result == errProduceSuccess {
+			sp.lastOffset++
+			msg.Offset = sp.lastOffset
+			return 0, msg.Offset, nil
+		}
+		return -1, -1, expectation.Result
+	}
+	sp.t.Errorf("No more expectation set on this mock producer to handle the input message.")
+	return -1, -1, errOutOfExpectations
+}
+
+// SendMessages corresponds with the SendMessages method of sarama's SyncProducer implementation.
+// You have to set expectations on the mock producer before calling SendMessages, so it knows
+// how to handle them. If there is no more remaining expectations when SendMessages is called,
+// the mock producer will write an error to the test state object.
+func (sp *SyncProducer) SendMessages(msgs []*sarama.ProducerMessage) error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) >= len(msgs) {
+		expectations := sp.expectations[0:len(msgs)]
+		sp.expectations = sp.expectations[len(msgs):]
+
+		for i, expectation := range expectations {
+			if expectation.CheckFunction != nil {
+				val, err := msgs[i].Value.Encode()
+				if err != nil {
+					sp.t.Errorf("Input message encoding failed: %s", err.Error())
+					return err
+				}
+				errCheck := expectation.CheckFunction(val)
+				if errCheck != nil {
+					sp.t.Errorf("Check function returned an error: %s", errCheck.Error())
+					return errCheck
+				}
+			}
+			if expectation.Result != errProduceSuccess {
+				return expectation.Result
+			}
+		}
+		return nil
+	}
+	sp.t.Errorf("Insufficient expectations set on this mock producer to handle the input messages.")
+	return errOutOfExpectations
+}
+
+// Close corresponds with the Close method of sarama's SyncProducer implementation.
+// By closing a mock syncproducer, you also tell it that no more SendMessage calls will follow,
+// so it will write an error to the test state if there's any remaining expectations.
+func (sp *SyncProducer) Close() error {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+
+	if len(sp.expectations) > 0 {
+		sp.t.Errorf("Expected to exhaust all expectations, but %d are left.", len(sp.expectations))
+	}
+
+	return nil
+}
+
+////////////////////////////////////////////////
+// Setting expectations
+////////////////////////////////////////////////
+
+// ExpectSendMessageWithCheckerFunctionAndSucceed sets an expectation on the mock producer that SendMessage
+// will be called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it produced
+// successfully, i.e. by returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndSucceed(cf ValueChecker) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: errProduceSuccess, CheckFunction: cf})
+}
+
+// ExpectSendMessageWithCheckerFunctionAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will first call the given function to check the message value.
+// It will cascade the error of the function, if any, or handle the message as if it failed
+// to produce successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageWithCheckerFunctionAndFail(cf ValueChecker, err error) {
+	sp.l.Lock()
+	defer sp.l.Unlock()
+	sp.expectations = append(sp.expectations, &producerExpectation{Result: err, CheckFunction: cf})
+}
+
+// ExpectSendMessageAndSucceed sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it produced successfully, i.e. by
+// returning a valid partition, and offset, and a nil error.
+func (sp *SyncProducer) ExpectSendMessageAndSucceed() {
+	sp.ExpectSendMessageWithCheckerFunctionAndSucceed(nil)
+}
+
+// ExpectSendMessageAndFail sets an expectation on the mock producer that SendMessage will be
+// called. The mock producer will handle the message as if it failed to produce
+// successfully, i.e. by returning the provided error.
+func (sp *SyncProducer) ExpectSendMessageAndFail(err error) {
+	sp.ExpectSendMessageWithCheckerFunctionAndFail(nil, err)
+}


### PR DESCRIPTION
Support publishing to multiple Kafka topics with restriction by org id:
- in the Kafka publisher: options "metrics-topic" and "metrics-partition-scheme" were amended to support multiple comma separated values; they remain backwards compatible
- in the Kafka publisher: a new option "only-org-id" was added which restricts which data get sent to each Kafka topic depending on the data's org id. An empty value or 0 means unrestricted
- a completion of vendored sarama was necessary to access the mocks for testing
- Int64SliceFlag was moved to the util package to allow reuse