### PR TITLE
 Added option 'discard-prefixes' that discards data points of series starting with the given prefixes

### DIFF
--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -306,7 +306,16 @@ func (m *mtPublisher) Publish(metrics []*schema.MetricData) error {
 				return err
 			}
 
-			if topic.onlyOrgId == 0 || metric.OrgId == topic.onlyOrgId {
+			prefixDiscarded := false
+			for _, prefix := range topic.discardPrefixes {
+				if strings.HasPrefix(metric.Name, prefix) {
+					prefixDiscarded = true
+					break
+				}
+			}
+
+			if (topic.onlyOrgId == 0 || metric.OrgId == topic.onlyOrgId) &&
+				!prefixDiscarded {
 				message := &sarama.ProducerMessage{
 					Key:   sarama.ByteEncoder(key),
 					Topic: topic.name,

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -138,23 +138,20 @@ func parseTopicSettings(partitionSchemesStr, topicsStr string, onlyOrgIds []int6
 			onlyOrgId = onlyOrgIds[i]
 		}
 
-		var discardPrefixes []string
-		if len(discardPrefixesStrList) == 0 {
-			discardPrefixes = nil
-		} else {
+		topic := topicSettings{
+			name:        topicName,
+			partitioner: partitioner,
+			onlyOrgId:   int(onlyOrgId),
+		}
+
+		if len(discardPrefixesStrList) > 0 {
 			// split prefixes by '|'; similar to strings.Split() but removes empty splits
 			f := func(c rune) bool {
 				return c == '|'
 			}
-			discardPrefixes = strings.FieldsFunc(discardPrefixesStrList[i], f)
+			topic.discardPrefixes = strings.FieldsFunc(discardPrefixesStrList[i], f)
 		}
 
-		topic := topicSettings{
-			name:            topicName,
-			partitioner:     partitioner,
-			onlyOrgId:       int(onlyOrgId),
-			discardPrefixes: discardPrefixes,
-		}
 		topics = append(topics, topic)
 	}
 	return topics, nil

--- a/publish/kafka/publish.go
+++ b/publish/kafka/publish.go
@@ -142,7 +142,11 @@ func parseTopicSettings(partitionSchemesStr, topicsStr string, onlyOrgIds []int6
 		if len(discardPrefixesStrList) == 0 {
 			discardPrefixes = nil
 		} else {
-			discardPrefixes = strings.Split(discardPrefixesStrList[i], "|")
+			// split prefixes by '|'; similar to strings.Split() but removes empty splits
+			f := func(c rune) bool {
+				return c == '|'
+			}
+			discardPrefixes = strings.FieldsFunc(discardPrefixesStrList[i], f)
 		}
 
 		topic := topicSettings{

--- a/publish/kafka/publish_test.go
+++ b/publish/kafka/publish_test.go
@@ -333,6 +333,34 @@ func Test_parseTopicSettings(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:                "two_topics_discard_prefix_second_only",
+			partitionSchemesStr: "bySeries,bySeries",
+			topicsStr:           "testTopic1,testTopic2",
+			onlyOrgIdsStr:       "",
+			discardPrefixesStr:  ",prefix2a|prefix2b",
+			expected: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					onlyOrgId:       0,
+					discardPrefixes: []string{},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					onlyOrgId:       0,
+					discardPrefixes: []string{"prefix2a", "prefix2b"},
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/publish/kafka/publish_test.go
+++ b/publish/kafka/publish_test.go
@@ -492,6 +492,40 @@ func Test_Publish(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "single_topic_discard_all_prefixes",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					discardPrefixes: []string{"a.b.c"},
+				},
+			},
+			data:         dataManyPoints,
+			expectedData: nil,
+			wantErr:      false,
+		},
+		{
+			name: "single_topic_discard_one_prefix",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					discardPrefixes: []string{"a.b.c2"},
+				},
+			},
+			data: dataManyPoints,
+			expectedData: map[string][]*schema.MetricData{
+				"testTopic": dataManyPoints[:len(dataManyPoints)-1],
+			},
+			wantErr: false,
+		},
+		{
 			name: "two_topics_single_point",
 			topics: []topicSettings{
 				topicSettings{
@@ -538,6 +572,32 @@ func Test_Publish(t *testing.T) {
 			expectedData: map[string][]*schema.MetricData{
 				"testTopic1": dataManyPoints,
 				"testTopic2": dataManyPoints,
+			},
+			wantErr: false,
+		},
+		{
+			name: "two_topics_many_points_discard_prefix_one_topic",
+			topics: []topicSettings{
+				topicSettings{
+					name: "testTopic1",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "bySeries",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+				},
+				topicSettings{
+					name: "testTopic2",
+					partitioner: &partitioner.Kafka{
+						PartitionBy: "byOrg",
+						Partitioner: sarama.NewHashPartitioner(""),
+					},
+					discardPrefixes: []string{"a.b.c2"},
+				},
+			},
+			data: dataManyPoints,
+			expectedData: map[string][]*schema.MetricData{
+				"testTopic1": dataManyPoints,
+				"testTopic2": dataManyPoints[:len(dataManyPoints)-1],
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Added option 'discard-prefixes' that discards data points of series starting with the given prefixes.

This is needed during instance migrations so that the target instance does not receive metrics that are internal/specific to the source instance such as:
`tsdb-gw.stats.local-cluster-10-cassandra.tsdb-10-byseries-32-cassandra-55fdd66b98-86xwq`
`metrictank.stats.local-cluster-10-cassandra.mt-read00-10-byseries-32-cassandra-a-758966f4c8-8lk76`