### PR TITLE
update vendored metrictank

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -258,7 +258,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:709d0d670f4588efb0a9ba483ad31cb7e46b3bd65594109e3911377c7525f281"
+  digest = "1:77092d96d2ca4b46b3ba0ae86abd609514528496916cdab56ed2c9d099a6a0ef"
   name = "github.com/grafana/metrictank"
   packages = [
     "cluster/partitioner",
@@ -273,7 +273,7 @@
     "util",
   ]
   pruneopts = "NUT"
-  revision = "da447e66475ce3228dafa05ed7f674a9b46c31c5"
+  revision = "c7715cb2dd264a00e595125ae16771b5696c40d4"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/grafana/metrictank/schema/metric.go
+++ b/vendor/github.com/grafana/metrictank/schema/metric.go
@@ -47,6 +47,7 @@ func (m *MetricData) Validate() error {
 	if m.Interval == 0 {
 		return ErrInvalidIntervalzero
 	}
+	m.Name = EatDots(m.Name)
 	if m.Name == "" {
 		return ErrInvalidEmptyName
 	}
@@ -192,6 +193,7 @@ func (m *MetricDefinition) Validate() error {
 	if m.Interval == 0 {
 		return ErrInvalidIntervalzero
 	}
+	m.Name = EatDots(m.Name)
 	if m.Name == "" {
 		return ErrInvalidEmptyName
 	}


### PR DESCRIPTION
The udpated code from Metrictank now uses the EatDots
function which will clean up bad metric names.
Validate() is already called on all ingested metrics before
they are sent to be published, so the code will already be
in use.