### PR TITLE
add optional rate limiter

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -724,6 +724,14 @@
   version = "v0.3.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:9fdc2b55e8e0fafe4b41884091e51e77344f7dc511c5acedcfd98200003bff90"
+  name = "golang.org/x/time"
+  packages = ["rate"]
+  pruneopts = "NUT"
+  revision = "9d24e82272b4f38b78bc8cff74fa936d31ccd8ef"
+
+[[projects]]
   digest = "1:286d3ed3b6c0d900ebef984bfab1b50b08f82a2f13ad9bb51e9be299f7f75200"
   name = "google.golang.org/api"
   packages = [
@@ -876,6 +884,7 @@
     "golang.org/x/net/context/ctxhttp",
     "golang.org/x/net/http/httpguts",
     "golang.org/x/sync/singleflight",
+    "golang.org/x/time/rate",
     "gopkg.in/ini.v1",
     "gopkg.in/macaron.v1",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -100,3 +100,7 @@ ignored = [
 go-tests = true
 non-go = true
 unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "golang.org/x/time"

--- a/api/limits_test.go
+++ b/api/limits_test.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/grafana/metrictank/schema"
+	"github.com/raintank/tsdb-gw/api/models"
+	"github.com/raintank/tsdb-gw/ingest"
+	"github.com/raintank/tsdb-gw/publish"
+	"gopkg.in/macaron.v1"
+)
+
+func TestRateLimitHander(t *testing.T) {
+	publish.Init(nil)
+	m := macaron.New()
+	m.Use(macaron.Renderer())
+	setOrg := func(ctx *models.Context) {
+		ctx.User.ID = 1
+	}
+	m.Router.Post("/metrics", GetContextHandler(), setOrg, IngestRateLimiter(), ingest.Metrics)
+	ts := httptest.NewServer(m)
+	defer ts.Close()
+
+	ingest.ConfigureRateLimits("1:100")
+
+	// send two requests so we hit our limit
+	for i := 0; i < 2; i++ {
+		err := sendData(t, ts.URL, 50)
+		if err != nil {
+			t.Fatalf("got err: %s", err)
+		}
+	}
+	// send another request, this should get rejected as we have
+	// already exceeded our limit
+	err := sendData(t, ts.URL, 50)
+	if err == nil {
+		t.Fatalf("expected to be rate limited but weren't")
+	}
+	// sleep so our rate drops to 0
+	time.Sleep(time.Second)
+
+	// send a request that almost hits the limit, but not quite
+	err = sendData(t, ts.URL, 98)
+	if err != nil {
+		t.Fatalf("got err: %s", err)
+	}
+
+	// send a request that is almost the full limit.  This should get blocked
+	// for close to 1 second before being processed.
+	pre := time.Now()
+	err = sendData(t, ts.URL, 99)
+	if err != nil {
+		t.Fatalf("expected to be rate limited but weren't")
+	}
+	if time.Since(pre) < time.Millisecond*500 {
+		t.Fatalf("expected request to be delayed due to limit")
+	}
+}
+
+func sendData(t *testing.T, url string, numPoints int) error {
+	metrics := make([]*schema.MetricData, numPoints)
+	for i := 0; i < numPoints; i++ {
+		metrics[i] = &schema.MetricData{
+			Name:     fmt.Sprintf("foo.blah.%d", i),
+			Time:     time.Now().Unix(),
+			Interval: 10,
+		}
+	}
+	b, err := json.Marshal(metrics)
+	if err != nil {
+		return err
+	}
+	buf := bytes.NewBuffer(b)
+	res, err := http.Post(url+"/metrics", "application/json", buf)
+
+	if err != nil {
+		return err
+	}
+	body, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	if err != nil {
+		return err
+	}
+
+	t.Logf("%d: %s", res.StatusCode, body)
+	if res.StatusCode >= 300 {
+		return fmt.Errorf("%d %s", res.StatusCode, body)
+	}
+	return nil
+}

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -21,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/raintank/tsdb-gw/api/models"
 	"github.com/raintank/tsdb-gw/auth"
+	"github.com/raintank/tsdb-gw/ingest"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/macaron.v1"
 )
@@ -99,7 +100,17 @@ func RequireViewer() macaron.Handler {
 	}
 }
 
-func (a *Api) GenerateHandlers(kind string, enforceRoles bool, datadog bool, handlers ...macaron.Handler) []macaron.Handler {
+func rateLimiter() macaron.Handler {
+	return func(ctx *models.Context) {
+		if !ingest.IsRateBudgetAvailable(ctx.Req.Context(), ctx.ID) {
+			log.Infof("Rejecting request for %d due to rate limit", ctx.ID)
+			ctx.JSON(429, "Rate limit is exhausted")
+			return
+		}
+	}
+}
+
+func (a *Api) GenerateHandlers(kind string, enforceRoles, datadog bool, handlers ...macaron.Handler) []macaron.Handler {
 	combinedHandlers := []macaron.Handler{}
 	if kind == "write" {
 		if datadog {
@@ -116,6 +127,11 @@ func (a *Api) GenerateHandlers(kind string, enforceRoles bool, datadog bool, han
 			combinedHandlers = append(combinedHandlers, RequirePublisher())
 		}
 	}
+
+	if ingest.UseRateLimit() {
+		combinedHandlers = append(combinedHandlers, rateLimiter())
+	}
+
 	return append(combinedHandlers, handlers...)
 }
 

--- a/api/middleware.go
+++ b/api/middleware.go
@@ -100,11 +100,11 @@ func RequireViewer() macaron.Handler {
 	}
 }
 
-func rateLimiter() macaron.Handler {
+func IngestRateLimiter() macaron.Handler {
 	return func(ctx *models.Context) {
 		if !ingest.IsRateBudgetAvailable(ctx.Req.Context(), ctx.ID) {
 			log.Infof("Rejecting request for %d due to rate limit", ctx.ID)
-			ctx.JSON(429, "Rate limit is exhausted")
+			ctx.JSON(http.StatusTooManyRequests, "Rate limit is exhausted")
 			return
 		}
 	}
@@ -129,7 +129,7 @@ func (a *Api) GenerateHandlers(kind string, enforceRoles, datadog bool, handlers
 	}
 
 	if ingest.UseRateLimit() {
-		combinedHandlers = append(combinedHandlers, rateLimiter())
+		combinedHandlers = append(combinedHandlers, IngestRateLimiter())
 	}
 
 	return append(combinedHandlers, handlers...)

--- a/cmd/tsdb-gw/main.go
+++ b/cmd/tsdb-gw/main.go
@@ -54,6 +54,7 @@ var (
 
 	// limitations
 	timerangeLimit = flag.String("timerange-limit", "", "define maximum timerange to serve queries for")
+	rateLimits     = flag.String("rate-limits", "", "define rate limits in the format \"<orgId>:<limit>;<orgId>;<limit>\"")
 
 	metricsAddr = flag.String("metrics-addr", ":8001", "http service address for the /metrics endpoint")
 )
@@ -119,6 +120,10 @@ func main() {
 		if err := ingest.InitMtBulkImporter(*importerURL); err != nil {
 			log.Fatalf(err.Error())
 		}
+	}
+
+	if err := ingest.ConfigureRateLimits(*rateLimits); err != nil {
+		log.Fatalf(err.Error())
 	}
 
 	inputs := make([]Stoppable, 0)

--- a/cmd/tsdb-gw/main.go
+++ b/cmd/tsdb-gw/main.go
@@ -54,7 +54,7 @@ var (
 
 	// limitations
 	timerangeLimit = flag.String("timerange-limit", "", "define maximum timerange to serve queries for")
-	rateLimits     = flag.String("rate-limits", "", "define rate limits in the format \"<orgId>:<limit>;<orgId>:<limit>\"")
+	rateLimits     = flag.String("rate-limits", "", "define rate limits in the format \"<orgId>:<limit>;<orgId>:<limit>\" where <limit> is the number of datapoints per second")
 
 	metricsAddr = flag.String("metrics-addr", ":8001", "http service address for the /metrics endpoint")
 )

--- a/cmd/tsdb-gw/main.go
+++ b/cmd/tsdb-gw/main.go
@@ -54,7 +54,7 @@ var (
 
 	// limitations
 	timerangeLimit = flag.String("timerange-limit", "", "define maximum timerange to serve queries for")
-	rateLimits     = flag.String("rate-limits", "", "define rate limits in the format \"<orgId>:<limit>;<orgId>;<limit>\"")
+	rateLimits     = flag.String("rate-limits", "", "define rate limits in the format \"<orgId>:<limit>;<orgId>:<limit>\"")
 
 	metricsAddr = flag.String("metrics-addr", ":8001", "http service address for the /metrics endpoint")
 )

--- a/ingest/metrics.go
+++ b/ingest/metrics.go
@@ -1,13 +1,11 @@
 package ingest
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/golang/snappy"
@@ -19,7 +17,6 @@ import (
 	"github.com/raintank/tsdb-gw/api/models"
 	"github.com/raintank/tsdb-gw/publish"
 	log "github.com/sirupsen/logrus"
-	"golang.org/x/time/rate"
 )
 
 var (
@@ -37,53 +34,7 @@ var (
 		},
 		[]string{"reason", "org"},
 	)
-
-	rateLimiters map[int]*rate.Limiter // org id -> rate limiter
 )
-
-func ConfigureRateLimits(limitStr string) error {
-	if len(limitStr) == 0 {
-		return nil
-	}
-
-	rateLimiters = make(map[int]*rate.Limiter)
-
-	limitsWithOrgs := strings.Split(limitStr, ";")
-	for _, limitWithOrg := range limitsWithOrgs {
-		limitWithOrgParts := strings.SplitN(limitWithOrg, ":", 2)
-		if len(limitWithOrgParts) != 2 {
-			return fmt.Errorf("Invalid limit configuration string: %q", limitWithOrg)
-		}
-
-		orgId, err := strconv.ParseInt(limitWithOrgParts[0], 10, 32)
-		if err != nil {
-			return fmt.Errorf("Unable to parse orgId from string: %q", limitWithOrgParts[0])
-		}
-
-		limit, err := strconv.ParseInt(limitWithOrgParts[1], 10, 32)
-		if err != nil {
-			return fmt.Errorf("Unable to parse rate limit from string: %q", limitWithOrgParts[1])
-		}
-
-		rateLimiters[int(orgId)] = rate.NewLimiter(rate.Limit(limit), int(limit))
-	}
-
-	return nil
-}
-
-func rateLimit(ctx context.Context, orgId, datapoints int) {
-	limiter, ok := rateLimiters[orgId]
-	if !ok {
-		return
-	}
-
-	// if the number of datapoints is larger than the secondly budget this will return an error
-	// which we then ignore
-	// TODO:
-	// figure out what to do if one single request contains more datapoints than the secondly budget,
-	// currently this request would not be limited
-	limiter.WaitN(ctx, datapoints)
-}
 
 func getMetricsTimestampStat(org int) *stats.Range32 {
 	metricsTSLock.Lock()
@@ -191,7 +142,7 @@ func metricsJson(ctx *models.Context) {
 	toPublish := make([]*schema.MetricData, 0, len(metrics))
 	toPublish, resp := prepareIngest(ctx, metrics, toPublish)
 
-	if len(rateLimiters) > 0 {
+	if UseRateLimit() {
 		rateLimit(ctx.Req.Context(), ctx.ID, len(toPublish))
 	}
 
@@ -256,7 +207,7 @@ func metricsBinary(ctx *models.Context, compressed bool) {
 	toPublish := make([]*schema.MetricData, 0, len(metricData.Metrics))
 	toPublish, resp := prepareIngest(ctx, metricData.Metrics, toPublish)
 
-	if len(rateLimiters) > 0 {
+	if UseRateLimit() {
 		rateLimit(ctx.Req.Context(), ctx.ID, len(toPublish))
 	}
 

--- a/ingest/rate_limit.go
+++ b/ingest/rate_limit.go
@@ -1,0 +1,67 @@
+package ingest
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"golang.org/x/time/rate"
+)
+
+var (
+	rateLimiters map[int]*rate.Limiter // org id -> rate limiter
+)
+
+func ConfigureRateLimits(limitStr string) error {
+	if len(limitStr) == 0 {
+		return nil
+	}
+
+	rateLimiters = make(map[int]*rate.Limiter)
+
+	limitsWithOrgs := strings.Split(limitStr, ";")
+	for _, limitWithOrg := range limitsWithOrgs {
+		limitWithOrgParts := strings.SplitN(limitWithOrg, ":", 2)
+		if len(limitWithOrgParts) != 2 {
+			return fmt.Errorf("Invalid limit configuration string: %q", limitWithOrg)
+		}
+
+		orgId, err := strconv.ParseInt(limitWithOrgParts[0], 10, 32)
+		if err != nil {
+			return fmt.Errorf("Unable to parse orgId from string: %q", limitWithOrgParts[0])
+		}
+
+		limit, err := strconv.ParseInt(limitWithOrgParts[1], 10, 32)
+		if err != nil {
+			return fmt.Errorf("Unable to parse rate limit from string: %q", limitWithOrgParts[1])
+		}
+
+		rateLimiters[int(orgId)] = rate.NewLimiter(rate.Limit(limit), int(limit))
+	}
+
+	return nil
+}
+
+func rateLimit(ctx context.Context, orgId, datapoints int) {
+	limiter, ok := rateLimiters[orgId]
+	if !ok {
+		return
+	}
+
+	// wait until we are allowed to publish the given number of datapoints
+	limiter.WaitN(ctx, datapoints)
+}
+
+func IsRateBudgetAvailable(ctx context.Context, orgId int) bool {
+	limiter, ok := rateLimiters[orgId]
+	if !ok {
+		return true
+	}
+
+	return limiter.Allow()
+}
+
+func UseRateLimit() bool {
+	return len(rateLimiters) > 0
+}

--- a/ingest/rate_limit_test.go
+++ b/ingest/rate_limit_test.go
@@ -164,12 +164,12 @@ func TestLimitingRate(t *testing.T) {
 				}(datapoints)
 			}
 
-			if ingestedDatapoints < tt.expectedIngestedDatapointsMin || ingestedDatapoints > tt.expectedIngestedDatapointsMax {
-				t.Fatalf("ingested datapoints is outside expected range. Expected %d - %d, Got %d", tt.expectedIngestedDatapointsMin, tt.expectedIngestedDatapointsMax, ingestedDatapoints)
+			if atomic.LoadUint32(&ingestedDatapoints) < tt.expectedIngestedDatapointsMin || atomic.LoadUint32(&ingestedDatapoints) > tt.expectedIngestedDatapointsMax {
+				t.Fatalf("ingested datapoints is outside expected range. Expected %d - %d, Got %d", tt.expectedIngestedDatapointsMin, tt.expectedIngestedDatapointsMax, atomic.LoadUint32(&ingestedDatapoints))
 			}
 
-			if rejectedRequests < tt.expectedRejectedRequestsMin || rejectedRequests > tt.expectedRejectedRequestsMax {
-				t.Fatalf("rejected requests is outside expected range. Expected %d - %d, Got %d", tt.expectedRejectedRequestsMin, tt.expectedRejectedRequestsMax, rejectedRequests)
+			if atomic.LoadUint32(&rejectedRequests) < tt.expectedRejectedRequestsMin || atomic.LoadUint32(&rejectedRequests) > tt.expectedRejectedRequestsMax {
+				t.Fatalf("rejected requests is outside expected range. Expected %d - %d, Got %d", tt.expectedRejectedRequestsMin, tt.expectedRejectedRequestsMax, atomic.LoadUint32(&rejectedRequests))
 			}
 		})
 	}

--- a/ingest/rate_limit_test.go
+++ b/ingest/rate_limit_test.go
@@ -1,0 +1,176 @@
+package ingest
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+func TestConfigureRateLimits(t *testing.T) {
+	tests := []struct {
+		name             string
+		limitStr         string
+		wantErr          bool
+		expectedLimiters map[int]int // org id -> limit
+	}{
+		{
+			name:             "simple single org",
+			limitStr:         "22:1000",
+			wantErr:          false,
+			expectedLimiters: map[int]int{22: 1000},
+		},
+		{
+			name:             "simple multi org",
+			limitStr:         "22:1000;23:10;100:1000",
+			wantErr:          false,
+			expectedLimiters: map[int]int{22: 1000, 23: 10, 100: 1000},
+		},
+		{
+			name:             "invalid format",
+			limitStr:         "22:1000;23:10:100:1000",
+			wantErr:          true,
+			expectedLimiters: map[int]int{},
+		},
+		{
+			name:             "invalid another format",
+			limitStr:         "22:1000;23;10;100:1000",
+			wantErr:          true,
+			expectedLimiters: map[int]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ConfigureRateLimits(tt.limitStr); (err != nil) != tt.wantErr {
+				t.Errorf("ConfigureRateLimits() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			for orgId, expectedLimit := range tt.expectedLimiters {
+				if limiter, ok := rateLimiters[orgId]; !ok {
+					t.Fatalf("Expected limit for org %d, but there was none", orgId)
+				} else {
+					if limiter.Limit() != rate.Limit(expectedLimit) {
+						t.Fatalf("Expected org %d to have limit %d, but it had %d", orgId, expectedLimit, int(limiter.Limit()))
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestLimitingRate is a bit racy, but since it tests a rate limiter I can't think of a better way to do it
+func TestLimitingRate(t *testing.T) {
+	tests := []struct {
+		name                          string
+		limitStr                      string
+		wantErr                       bool
+		orgId                         int
+		requestRate                   int    // how many requests we receive per second
+		datapointsPerRequest          int    // how many datapoints are in each request
+		testTime                      int    // number of seconds to run the test
+		expectedIngestedDatapointsMin uint32 // min number of datapoints that should get ingested
+		expectedIngestedDatapointsMax uint32 // max number of datapoints that should get ingested
+		expectedRejectedRequestsMin   uint32 // min number of requests that should get rejected
+		expectedRejectedRequestsMax   uint32 // max number of requests that should get rejected
+	}{
+		{
+			name:                 "1000 datapoints/sec, 100 reqs/sec, 100 datapoints/req",
+			limitStr:             "1:1000",
+			wantErr:              false,
+			orgId:                1,
+			requestRate:          100,
+			datapointsPerRequest: 100,
+			testTime:             10,
+
+			// - we're receiving 100 requests per second, with 100 datapoints per request, we permit 1000 datapoints per second, we're testing for 10 seconds
+			// - roughly 10000 datapoints should get ingested in total
+			// - in total 1000 requests should be made, out of which around 100 (10000/100) should get accepted, around 900 should get rejected
+			expectedIngestedDatapointsMin: 9000,
+			expectedIngestedDatapointsMax: 11000,
+			expectedRejectedRequestsMin:   800,
+			expectedRejectedRequestsMax:   1000,
+		}, {
+			name:                 "100 datapoints/sec, 10 reqs/sec, 50 datapoints/req",
+			limitStr:             "1:100",
+			wantErr:              false,
+			orgId:                1,
+			requestRate:          10,
+			datapointsPerRequest: 50,
+			testTime:             10,
+
+			// - we're receiving 10 requests per second, with 50 datapoints per request, we permit 100 datapoints per second, we're testing for 10 seconds
+			// - roughly 1000 datapoints should get ingested in total
+			// - in total 100 requests should be made, out of which around 20 (1000/50) should get accepted, around 80 should get rejected
+			expectedIngestedDatapointsMin: 900,
+			expectedIngestedDatapointsMax: 1100,
+			expectedRejectedRequestsMin:   70,
+			expectedRejectedRequestsMax:   90,
+		}, {
+			name:                 "333 datapoints/sec, 7 reqs/sec, 123 datapoints/req",
+			limitStr:             "1:333",
+			wantErr:              false,
+			orgId:                1,
+			requestRate:          7,
+			datapointsPerRequest: 123,
+			testTime:             10,
+
+			// - we're receiving 7 requests per second, with 123 datapoints per request, we permit 333 datapoints per second, we're testing for 10 seconds
+			// - roughly 3333 datapoints should get ingested in total
+			// - in total 70 requests should be made, out of which around 27 (3333/123) should get accepted, around 43 should get rejected
+			expectedIngestedDatapointsMin: 3300,
+			expectedIngestedDatapointsMax: 3600,
+			expectedRejectedRequestsMin:   35,
+			expectedRejectedRequestsMax:   50,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ConfigureRateLimits(tt.limitStr); (err != nil) != tt.wantErr {
+				t.Errorf("ConfigureRateLimits() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			done := time.NewTimer(time.Duration(tt.testTime) * time.Second)
+			requestCh := make(chan int, 1000)
+
+			go func() {
+				ticker := time.NewTicker(time.Second / time.Duration(tt.requestRate))
+				defer ticker.Stop()
+				defer close(requestCh)
+
+				for range ticker.C {
+					select {
+					case <-done.C:
+						return
+					case requestCh <- tt.datapointsPerRequest:
+					default:
+					}
+				}
+			}()
+
+			var ingestedDatapoints, rejectedRequests uint32
+
+			for datapoints := range requestCh {
+				go func(datapoints int) {
+					ctx := context.Background()
+					if IsRateBudgetAvailable(ctx, tt.orgId) {
+						rateLimit(ctx, tt.orgId, datapoints)
+						atomic.AddUint32(&ingestedDatapoints, uint32(datapoints))
+					} else {
+						atomic.AddUint32(&rejectedRequests, 1)
+					}
+				}(datapoints)
+			}
+
+			if ingestedDatapoints < tt.expectedIngestedDatapointsMin || ingestedDatapoints > tt.expectedIngestedDatapointsMax {
+				t.Fatalf("ingested datapoints is outside expected range. Expected %d - %d, Got %d", tt.expectedIngestedDatapointsMin, tt.expectedIngestedDatapointsMax, ingestedDatapoints)
+			}
+
+			if rejectedRequests < tt.expectedRejectedRequestsMin || rejectedRequests > tt.expectedRejectedRequestsMax {
+				t.Fatalf("rejected requests is outside expected range. Expected %d - %d, Got %d", tt.expectedRejectedRequestsMin, tt.expectedRejectedRequestsMax, rejectedRequests)
+			}
+		})
+	}
+}

--- a/vendor/golang.org/x/time/AUTHORS
+++ b/vendor/golang.org/x/time/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/time/CONTRIBUTORS
+++ b/vendor/golang.org/x/time/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/time/LICENSE
+++ b/vendor/golang.org/x/time/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/time/PATENTS
+++ b/vendor/golang.org/x/time/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/time/rate/rate.go
+++ b/vendor/golang.org/x/time/rate/rate.go
@@ -1,0 +1,374 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rate provides a rate limiter.
+package rate
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+)
+
+// Limit defines the maximum frequency of some events.
+// Limit is represented as number of events per second.
+// A zero Limit allows no events.
+type Limit float64
+
+// Inf is the infinite rate limit; it allows all events (even if burst is zero).
+const Inf = Limit(math.MaxFloat64)
+
+// Every converts a minimum time interval between events to a Limit.
+func Every(interval time.Duration) Limit {
+	if interval <= 0 {
+		return Inf
+	}
+	return 1 / Limit(interval.Seconds())
+}
+
+// A Limiter controls how frequently events are allowed to happen.
+// It implements a "token bucket" of size b, initially full and refilled
+// at rate r tokens per second.
+// Informally, in any large enough time interval, the Limiter limits the
+// rate to r tokens per second, with a maximum burst size of b events.
+// As a special case, if r == Inf (the infinite rate), b is ignored.
+// See https://en.wikipedia.org/wiki/Token_bucket for more about token buckets.
+//
+// The zero value is a valid Limiter, but it will reject all events.
+// Use NewLimiter to create non-zero Limiters.
+//
+// Limiter has three main methods, Allow, Reserve, and Wait.
+// Most callers should use Wait.
+//
+// Each of the three methods consumes a single token.
+// They differ in their behavior when no token is available.
+// If no token is available, Allow returns false.
+// If no token is available, Reserve returns a reservation for a future token
+// and the amount of time the caller must wait before using it.
+// If no token is available, Wait blocks until one can be obtained
+// or its associated context.Context is canceled.
+//
+// The methods AllowN, ReserveN, and WaitN consume n tokens.
+type Limiter struct {
+	limit Limit
+	burst int
+
+	mu     sync.Mutex
+	tokens float64
+	// last is the last time the limiter's tokens field was updated
+	last time.Time
+	// lastEvent is the latest time of a rate-limited event (past or future)
+	lastEvent time.Time
+}
+
+// Limit returns the maximum overall event rate.
+func (lim *Limiter) Limit() Limit {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+	return lim.limit
+}
+
+// Burst returns the maximum burst size. Burst is the maximum number of tokens
+// that can be consumed in a single call to Allow, Reserve, or Wait, so higher
+// Burst values allow more events to happen at once.
+// A zero Burst allows no events, unless limit == Inf.
+func (lim *Limiter) Burst() int {
+	return lim.burst
+}
+
+// NewLimiter returns a new Limiter that allows events up to rate r and permits
+// bursts of at most b tokens.
+func NewLimiter(r Limit, b int) *Limiter {
+	return &Limiter{
+		limit: r,
+		burst: b,
+	}
+}
+
+// Allow is shorthand for AllowN(time.Now(), 1).
+func (lim *Limiter) Allow() bool {
+	return lim.AllowN(time.Now(), 1)
+}
+
+// AllowN reports whether n events may happen at time now.
+// Use this method if you intend to drop / skip events that exceed the rate limit.
+// Otherwise use Reserve or Wait.
+func (lim *Limiter) AllowN(now time.Time, n int) bool {
+	return lim.reserveN(now, n, 0).ok
+}
+
+// A Reservation holds information about events that are permitted by a Limiter to happen after a delay.
+// A Reservation may be canceled, which may enable the Limiter to permit additional events.
+type Reservation struct {
+	ok        bool
+	lim       *Limiter
+	tokens    int
+	timeToAct time.Time
+	// This is the Limit at reservation time, it can change later.
+	limit Limit
+}
+
+// OK returns whether the limiter can provide the requested number of tokens
+// within the maximum wait time.  If OK is false, Delay returns InfDuration, and
+// Cancel does nothing.
+func (r *Reservation) OK() bool {
+	return r.ok
+}
+
+// Delay is shorthand for DelayFrom(time.Now()).
+func (r *Reservation) Delay() time.Duration {
+	return r.DelayFrom(time.Now())
+}
+
+// InfDuration is the duration returned by Delay when a Reservation is not OK.
+const InfDuration = time.Duration(1<<63 - 1)
+
+// DelayFrom returns the duration for which the reservation holder must wait
+// before taking the reserved action.  Zero duration means act immediately.
+// InfDuration means the limiter cannot grant the tokens requested in this
+// Reservation within the maximum wait time.
+func (r *Reservation) DelayFrom(now time.Time) time.Duration {
+	if !r.ok {
+		return InfDuration
+	}
+	delay := r.timeToAct.Sub(now)
+	if delay < 0 {
+		return 0
+	}
+	return delay
+}
+
+// Cancel is shorthand for CancelAt(time.Now()).
+func (r *Reservation) Cancel() {
+	r.CancelAt(time.Now())
+	return
+}
+
+// CancelAt indicates that the reservation holder will not perform the reserved action
+// and reverses the effects of this Reservation on the rate limit as much as possible,
+// considering that other reservations may have already been made.
+func (r *Reservation) CancelAt(now time.Time) {
+	if !r.ok {
+		return
+	}
+
+	r.lim.mu.Lock()
+	defer r.lim.mu.Unlock()
+
+	if r.lim.limit == Inf || r.tokens == 0 || r.timeToAct.Before(now) {
+		return
+	}
+
+	// calculate tokens to restore
+	// The duration between lim.lastEvent and r.timeToAct tells us how many tokens were reserved
+	// after r was obtained. These tokens should not be restored.
+	restoreTokens := float64(r.tokens) - r.limit.tokensFromDuration(r.lim.lastEvent.Sub(r.timeToAct))
+	if restoreTokens <= 0 {
+		return
+	}
+	// advance time to now
+	now, _, tokens := r.lim.advance(now)
+	// calculate new number of tokens
+	tokens += restoreTokens
+	if burst := float64(r.lim.burst); tokens > burst {
+		tokens = burst
+	}
+	// update state
+	r.lim.last = now
+	r.lim.tokens = tokens
+	if r.timeToAct == r.lim.lastEvent {
+		prevEvent := r.timeToAct.Add(r.limit.durationFromTokens(float64(-r.tokens)))
+		if !prevEvent.Before(now) {
+			r.lim.lastEvent = prevEvent
+		}
+	}
+
+	return
+}
+
+// Reserve is shorthand for ReserveN(time.Now(), 1).
+func (lim *Limiter) Reserve() *Reservation {
+	return lim.ReserveN(time.Now(), 1)
+}
+
+// ReserveN returns a Reservation that indicates how long the caller must wait before n events happen.
+// The Limiter takes this Reservation into account when allowing future events.
+// ReserveN returns false if n exceeds the Limiter's burst size.
+// Usage example:
+//   r := lim.ReserveN(time.Now(), 1)
+//   if !r.OK() {
+//     // Not allowed to act! Did you remember to set lim.burst to be > 0 ?
+//     return
+//   }
+//   time.Sleep(r.Delay())
+//   Act()
+// Use this method if you wish to wait and slow down in accordance with the rate limit without dropping events.
+// If you need to respect a deadline or cancel the delay, use Wait instead.
+// To drop or skip events exceeding rate limit, use Allow instead.
+func (lim *Limiter) ReserveN(now time.Time, n int) *Reservation {
+	r := lim.reserveN(now, n, InfDuration)
+	return &r
+}
+
+// Wait is shorthand for WaitN(ctx, 1).
+func (lim *Limiter) Wait(ctx context.Context) (err error) {
+	return lim.WaitN(ctx, 1)
+}
+
+// WaitN blocks until lim permits n events to happen.
+// It returns an error if n exceeds the Limiter's burst size, the Context is
+// canceled, or the expected wait time exceeds the Context's Deadline.
+// The burst limit is ignored if the rate limit is Inf.
+func (lim *Limiter) WaitN(ctx context.Context, n int) (err error) {
+	if n > lim.burst && lim.limit != Inf {
+		return fmt.Errorf("rate: Wait(n=%d) exceeds limiter's burst %d", n, lim.burst)
+	}
+	// Check if ctx is already cancelled
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	// Determine wait limit
+	now := time.Now()
+	waitLimit := InfDuration
+	if deadline, ok := ctx.Deadline(); ok {
+		waitLimit = deadline.Sub(now)
+	}
+	// Reserve
+	r := lim.reserveN(now, n, waitLimit)
+	if !r.ok {
+		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", n)
+	}
+	// Wait if necessary
+	delay := r.DelayFrom(now)
+	if delay == 0 {
+		return nil
+	}
+	t := time.NewTimer(delay)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		// We can proceed.
+		return nil
+	case <-ctx.Done():
+		// Context was canceled before we could proceed.  Cancel the
+		// reservation, which may permit other events to proceed sooner.
+		r.Cancel()
+		return ctx.Err()
+	}
+}
+
+// SetLimit is shorthand for SetLimitAt(time.Now(), newLimit).
+func (lim *Limiter) SetLimit(newLimit Limit) {
+	lim.SetLimitAt(time.Now(), newLimit)
+}
+
+// SetLimitAt sets a new Limit for the limiter. The new Limit, and Burst, may be violated
+// or underutilized by those which reserved (using Reserve or Wait) but did not yet act
+// before SetLimitAt was called.
+func (lim *Limiter) SetLimitAt(now time.Time, newLimit Limit) {
+	lim.mu.Lock()
+	defer lim.mu.Unlock()
+
+	now, _, tokens := lim.advance(now)
+
+	lim.last = now
+	lim.tokens = tokens
+	lim.limit = newLimit
+}
+
+// reserveN is a helper method for AllowN, ReserveN, and WaitN.
+// maxFutureReserve specifies the maximum reservation wait duration allowed.
+// reserveN returns Reservation, not *Reservation, to avoid allocation in AllowN and WaitN.
+func (lim *Limiter) reserveN(now time.Time, n int, maxFutureReserve time.Duration) Reservation {
+	lim.mu.Lock()
+
+	if lim.limit == Inf {
+		lim.mu.Unlock()
+		return Reservation{
+			ok:        true,
+			lim:       lim,
+			tokens:    n,
+			timeToAct: now,
+		}
+	}
+
+	now, last, tokens := lim.advance(now)
+
+	// Calculate the remaining number of tokens resulting from the request.
+	tokens -= float64(n)
+
+	// Calculate the wait duration
+	var waitDuration time.Duration
+	if tokens < 0 {
+		waitDuration = lim.limit.durationFromTokens(-tokens)
+	}
+
+	// Decide result
+	ok := n <= lim.burst && waitDuration <= maxFutureReserve
+
+	// Prepare reservation
+	r := Reservation{
+		ok:    ok,
+		lim:   lim,
+		limit: lim.limit,
+	}
+	if ok {
+		r.tokens = n
+		r.timeToAct = now.Add(waitDuration)
+	}
+
+	// Update state
+	if ok {
+		lim.last = now
+		lim.tokens = tokens
+		lim.lastEvent = r.timeToAct
+	} else {
+		lim.last = last
+	}
+
+	lim.mu.Unlock()
+	return r
+}
+
+// advance calculates and returns an updated state for lim resulting from the passage of time.
+// lim is not changed.
+func (lim *Limiter) advance(now time.Time) (newNow time.Time, newLast time.Time, newTokens float64) {
+	last := lim.last
+	if now.Before(last) {
+		last = now
+	}
+
+	// Avoid making delta overflow below when last is very old.
+	maxElapsed := lim.limit.durationFromTokens(float64(lim.burst) - lim.tokens)
+	elapsed := now.Sub(last)
+	if elapsed > maxElapsed {
+		elapsed = maxElapsed
+	}
+
+	// Calculate the new number of tokens, due to time that passed.
+	delta := lim.limit.tokensFromDuration(elapsed)
+	tokens := lim.tokens + delta
+	if burst := float64(lim.burst); tokens > burst {
+		tokens = burst
+	}
+
+	return now, last, tokens
+}
+
+// durationFromTokens is a unit conversion function from the number of tokens to the duration
+// of time it takes to accumulate them at a rate of limit tokens per second.
+func (limit Limit) durationFromTokens(tokens float64) time.Duration {
+	seconds := tokens / float64(limit)
+	return time.Nanosecond * time.Duration(1e9*seconds)
+}
+
+// tokensFromDuration is a unit conversion function from a time duration to the number of tokens
+// which could be accumulated during that duration at a rate of limit tokens per second.
+func (limit Limit) tokensFromDuration(d time.Duration) float64 {
+	return d.Seconds() * float64(limit)
+}


### PR DESCRIPTION
Related #134

I'm not sure what to do if a single request contains more datapoints than the secondly budget. 
I'd assume that this is a case that shouldn't happen unless we limit a user to an extremely low rate, or a user configures their crng to a huge batch size.
I think we could enforce something like a max batch size by responding with 429 if the received batch has more datapoints than the configured secondly rate. If a user does receive 429s they'd then have to configure their crng's max-batch-size.